### PR TITLE
Fix: 외부경로 중복 데이터 제거

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/navigate/service/OuterRouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/service/OuterRouteService.java
@@ -48,8 +48,7 @@ public class OuterRouteService {
                 String unparsedPath = (String) pathInfo.get("path");
                 String[] parsedPath = unparsedPath.split(" ");
                 for (int j = 0; j<parsedPath.length; j++){
-                    if ((LastIndex == -1) ||(!Objects.equals(routeList.get(LastIndex),
-                        parsedPath[j]))) {
+                    if ((LastIndex == -1) ||(!Objects.equals(routeList.get(LastIndex)[1]+","+routeList.get(LastIndex)[0],parsedPath[j]))) {
                         String[] splitPath = parsedPath[j].split(",");
                         String[] returnPath = {splitPath[1],splitPath[0]};
                         routeList.add(returnPath);


### PR DESCRIPTION
## 개요
외부경로 중복 데이터 제거

## 작업사항
OuterRouteService에서 데이터 형식 변화로 인해 생겨날 수 있는 중복 데이터 제거

