### PR TITLE
로그인 로직 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/oauth2/dto/OAuth2LoginRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/oauth2/dto/OAuth2LoginRes.java
@@ -1,8 +1,14 @@
 package devkor.com.teamcback.domain.oauth2.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 
-@JsonIgnoreProperties
+@Getter
 public class OAuth2LoginRes {
+    private String accessToken;
+    private String refreshToken;
 
+    public OAuth2LoginRes(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/devkor/com/teamcback/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -44,17 +44,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtUtil.createAccessToken(email, String.valueOf(role));
         String refreshToken = jwtUtil.createRefreshToken(email, String.valueOf(role));
 
-        addCookie(accessToken, JwtUtil.ACCESS_TOKEN_HEADER, response);
-        addCookie(refreshToken, JwtUtil.REFRESH_TOKEN_HEADER, response);
-
-        setResponse(response, new OAuth2LoginRes());
-    }
-
-    private void addCookie(String cookieValue, String header, HttpServletResponse res) {
-        Cookie cookie = new Cookie(header, cookieValue); // Name-Value
-        cookie.setPath("/");
-        cookie.setMaxAge(2 * 60 * 60); //쿠키 유효 기간(s) 2시간
-        res.addCookie(cookie);
+        setResponse(response, new OAuth2LoginRes(accessToken, refreshToken));
     }
 
     private void setResponse(HttpServletResponse response, Object data) throws IOException {

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -3,6 +3,8 @@ package devkor.com.teamcback.domain.user.entity;
 import devkor.com.teamcback.domain.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,6 +34,7 @@ public class User extends BaseEntity {
     private Role role;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Provider provider;
 
     public User(String username, String email, String profileUrl, Role role, Provider provider) {

--- a/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
 
-        String accessToken = jwtUtil.getAccessTokenFromCookie(request);
+        String accessToken = jwtUtil.getAccessTokenFromHeader(request);
         log.info("Access Token: {}", accessToken);
 
         // access token 비어있으면 인증 미처리
@@ -68,7 +68,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
      * Refresh token 검증 (access token이 만료된 경우)
      */
     private void authenticateRefreshToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
+        String refreshToken = jwtUtil.getRefreshTokenFromHeader(request);
         log.info("Refresh Token: {}", refreshToken);
 
         if(refreshToken == null) throw new GlobalException(REFRESH_TOKEN_REQUIRED); // refresh token 요청

--- a/src/main/java/devkor/com/teamcback/global/jwt/JwtUtil.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/JwtUtil.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Slf4j(topic = "JwtUtil")
 @Component
@@ -75,28 +76,25 @@ public class JwtUtil {
     }
 
     /**
-     * Cookie 에서 Access Token 가져오기
-     * @return Access Token 혹은 null
+     * Header 에서 Access Token 가져오기
+     * @return Bearer%20을 제거한 Access Token 혹은 null
      */
-    public String getAccessTokenFromCookie(HttpServletRequest request) {
-        return findValueInCookie(request, ACCESS_TOKEN_HEADER);
+    public String getAccessTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(ACCESS_TOKEN_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(9);
+        }
+        return null;
     }
 
     /**
-     * Cookie 에서 Refresh Token 가져오기
-     * @return Refresh Token 혹은 null
+     * Header 에서 Refresh Token 가져오기
+     * @return Bearer%20을 제거한 Refresh Token 혹은 null
      */
-    public String getRefreshTokenFromCookie(HttpServletRequest request) {
-        return findValueInCookie(request, REFRESH_TOKEN_HEADER);
-    }
-
-    private String findValueInCookie(HttpServletRequest request, String key) {
-        Cookie[] list = request.getCookies();
-        if(list != null) {
-            for (Cookie cookie : list) {
-                if (cookie.getName().equals(key))
-                    return cookie.getValue().substring(9);
-            }
+    public String getRefreshTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(REFRESH_TOKEN_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(9);
         }
         return null;
     }

--- a/src/main/java/devkor/com/teamcback/global/security/logout/LogoutHandlerImpl.java
+++ b/src/main/java/devkor/com/teamcback/global/security/logout/LogoutHandlerImpl.java
@@ -22,7 +22,7 @@ public class LogoutHandlerImpl implements LogoutHandler {
     public void logout(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) {
 
-        String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
+        String refreshToken = jwtUtil.getRefreshTokenFromHeader(request);
         log.info("refreshToken: {}", refreshToken);
 
         // 블랙리스트 처리: Redis에 저장

--- a/src/main/java/devkor/com/teamcback/global/security/logout/LogoutSuccessHandlerImpl.java
+++ b/src/main/java/devkor/com/teamcback/global/security/logout/LogoutSuccessHandlerImpl.java
@@ -29,9 +29,6 @@ public class LogoutSuccessHandlerImpl implements LogoutSuccessHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         response.getWriter().write(new ObjectMapper().writeValueAsString(CommonResponse.success(new UserLogoutRes())));
-
-        deleteCookie(response, JwtUtil.ACCESS_TOKEN_HEADER);
-        deleteCookie(response, JwtUtil.REFRESH_TOKEN_HEADER);
     }
 
     private void deleteCookie(HttpServletResponse response, String header) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,16 @@ jwt:
   secret:
     key: ${JWT_SECRET_KEY}
 
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+    credentials:
+      access-key: ${BUCKET_ACCESS_KEY}
+      secret-key: ${BUCKET_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+
 springdoc:
   api-docs:
     path: /api-docs
@@ -98,4 +108,4 @@ springdoc:
 
 default:
   image:
-    url:
+    url: https://kodaero.s3.ap-northeast-2.amazonaws.com/profile/default_profile_image.jpg


### PR DESCRIPTION
## 개요
로그인 시 토큰을 데이터로 보내고, 쿠키가 아닌 헤더로 요청을 받는 것으로 수정했습니다.
애플 로그인은 유료 프로그램 가입이 필요하다고 해서 하지 않았습니다.

## 작업사항
- 쿠키 -> 헤더에서 토큰을 가져옴
- 로그아웃 시 쿠키 삭제 로직은 제거
- 소셜 로그인 시 쿠키가 아닌 body에 토큰을 담아 전송
- 기본 프로필 사진 추가

## 관련 이슈
- 
