### PR TITLE
검색 기능 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/facility/repository/FacilityRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/facility/repository/FacilityRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FacilityRepository extends JpaRepository<Facility, Long> {
     boolean existsByBuildingAndType(Building building, FacilityType type);
 
+    List<Facility> findByNameContaining(String word);
+
     List<Facility> findAllByBuildingAndType(Building building, FacilityType type);
 
     List<Facility> findAllByBuilding(Building building);

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
@@ -47,7 +47,9 @@ public class GlobalSearchRes {
             this.name = classroom.getBuilding().getName() + " " + classroom.getName();
         }
         this.floor = classroom.getFloor();
-        this.detail = classroom.getDetail();
+        if (!classroom.getDetail().equals(".")) {
+            this.detail = classroom.getDetail();
+        }
         this.longitude = classroom.getNode().getLongitude();
         this.latitude = classroom.getNode().getLatitude();
         this.placeType = placeType;

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
@@ -3,6 +3,7 @@ package devkor.com.teamcback.domain.search.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.classroom.entity.Classroom;
+import devkor.com.teamcback.domain.facility.entity.Facility;
 import devkor.com.teamcback.domain.facility.entity.FacilityType;
 import devkor.com.teamcback.domain.search.entity.PlaceType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -48,8 +49,12 @@ public class GlobalSearchRes {
         this.placeType = placeType;
     }
 
-    public GlobalSearchRes(FacilityType facilityType, PlaceType placeType) {
-        this.name = facilityType.getName();
+    public GlobalSearchRes(Facility facility, PlaceType placeType) {
+        if (facility.getType().getName().equals(facility.getName())) {
+            this.name = facility.getName();
+        } else {
+            this.name = facility.getBuilding().getName() + " " + facility.getName();
+        }
         this.placeType = placeType;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
@@ -41,7 +41,11 @@ public class GlobalSearchRes {
 
     public GlobalSearchRes(Classroom classroom, PlaceType placeType) {
         this.id = classroom.getId();
-        this.name = classroom.getBuilding().getName() + " " + classroom.getName();
+        if (classroom.getBuilding().getId() == 0) {
+            this.name = classroom.getName();
+        } else {
+            this.name = classroom.getBuilding().getName() + " " + classroom.getName();
+        }
         this.floor = classroom.getFloor();
         this.detail = classroom.getDetail();
         this.longitude = classroom.getNode().getLongitude();
@@ -50,7 +54,7 @@ public class GlobalSearchRes {
     }
 
     public GlobalSearchRes(Facility facility, PlaceType placeType) {
-        if (facility.getType().getName().equals(facility.getName())) {
+        if (facility.getBuilding().getId() == 0 || facility.getType().getName().equals(facility.getName())) {
             this.name = facility.getName();
         } else {
             this.name = facility.getBuilding().getName() + " " + facility.getName();


### PR DESCRIPTION
1. facility 검색 결과 수정
-고대빵, 우당 박종구 라운지 등 특별한 이름이 있는 facility의 검색 결과를 확인할 수 있도록 수정하였습니다.
-일반 facility는 기존과 동일하게 넘어오며, 특별한 이름이 있는 편의시설은 “건물명 + 편의시설명”의 형태로 넘어오게 수정하였습니다.
ex. “라운지”로 검색 → 라운지 & 우당교양관 우당 박종구 라운지 처럼 출력

2. 검색 결과에 "야외"가 노출되지 않도록 수정
-”야외 폭풍의 언덕” → “폭풍의 언덕” 처럼 수정하였습니다.
-classroom / facility 모두 수정

3. facility의 detail은 “.”(기본값)이 아닌 경우에만 결과를 반환하도록 수정하였습니다. 나중에 detail도 nullable로 수정할 수 있다면 이 부분은 삭제해도 괜찮을 것 같습니다!