### PR TITLE
강의실, 건물 별명 관리용 API

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingImageController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingImageController.java
@@ -28,11 +28,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/buildings")
+@RequestMapping("/api/admin/buildings/images")
 public class AdminBuildingImageController {
     private final AdminBuildingImageService adminBuildingImageService;
 
-    @PostMapping(value = "/image",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "건물 내부 사진 저장",
         description = "건물 내부 사진 저장")
     @ApiResponses(value = {
@@ -53,7 +53,7 @@ public class AdminBuildingImageController {
             adminBuildingImageService.saveBuildingImage(buildingId, floor, image));
     }
 
-    @PutMapping(value = "/image/{buildingImageId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(value = "/{imageId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "건물 내부 사진 수정",
         description = "건물 내부 사진 수정")
     @ApiResponses(value = {
@@ -66,16 +66,16 @@ public class AdminBuildingImageController {
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<ModifyBuildingImageRes> modifyBuildingImage(
-        @Parameter(description = "수정할 건물 사진 ID") @PathVariable Long buildingImageId,
+        @Parameter(description = "수정할 건물 사진 ID") @PathVariable Long imageId,
         @Parameter(name = "buildingId", description = "건물 ID") @RequestParam Long buildingId,
         @Parameter(name = "floor", description = "건물 층 수") @RequestParam Double floor,
         @Parameter(description = "수정할 사진 파일") @RequestPart("image") MultipartFile image
     ) {
         return CommonResponse.success(
-            adminBuildingImageService.modifyBuildingImage(buildingImageId, buildingId, floor, image));
+            adminBuildingImageService.modifyBuildingImage(imageId, buildingId, floor, image));
     }
 
-    @DeleteMapping(value = "/image/{buildingImageId}")
+    @DeleteMapping(value = "/{imageId}")
     @Operation(summary = "건물 내부 사진 삭제",
         description = "건물 내부 사진 삭제")
     @ApiResponses(value = {
@@ -86,12 +86,12 @@ public class AdminBuildingImageController {
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<DeleteBuildingImageRes> deleteBuildingImage(
-        @Parameter(description = "삭제할 건물 사진 ID") @PathVariable Long buildingImageId
+        @Parameter(description = "삭제할 건물 사진 ID") @PathVariable Long imageId
     ) {
-        return CommonResponse.success(adminBuildingImageService.deleteBuildingImage(buildingImageId));
+        return CommonResponse.success(adminBuildingImageService.deleteBuildingImage(imageId));
     }
 
-    @GetMapping(value = "/image/{buildingImageId}")
+    @GetMapping(value = "/{imageId}")
     @Operation(summary = "건물 내부 사진 조회",
         description = "건물 내부 사진 조회")
     @ApiResponses(value = {
@@ -102,12 +102,12 @@ public class AdminBuildingImageController {
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<GetBuildingImageRes> getBuildingImage(
-        @Parameter(description = "조회할 건물 사진 ID") @PathVariable Long buildingImageId
+        @Parameter(description = "조회할 건물 사진 ID") @PathVariable Long imageId
     ) {
-        return CommonResponse.success(adminBuildingImageService.getBuildingImage(buildingImageId));
+        return CommonResponse.success(adminBuildingImageService.getBuildingImage(imageId));
     }
 
-    @GetMapping(value = "/image")
+    @GetMapping
     @Operation(summary = "건물 내부 사진 검색",
         description = "건물 내부 사진 검색")
     @ApiResponses(value = {

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingImageController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingImageController.java
@@ -1,11 +1,11 @@
-package devkor.com.teamcback.domain.admin.controller;
+package devkor.com.teamcback.domain.admin.building.controller;
 
-import devkor.com.teamcback.domain.admin.dto.response.DeleteBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.ModifyBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.SaveBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.SearchBuildingImageRes;
-import devkor.com.teamcback.domain.admin.service.AdminBuildingImageService;
+import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.ModifyBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.SearchBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.service.AdminBuildingImageService;
 import devkor.com.teamcback.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
@@ -2,6 +2,7 @@ package devkor.com.teamcback.domain.admin.building.controller;
 
 import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
 import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingNicknameRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingNicknameListRes;
 import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
 import devkor.com.teamcback.domain.admin.building.service.AdminBuildingNicknameService;
 import devkor.com.teamcback.global.response.CommonResponse;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,5 +56,20 @@ public class AdminBuildingNicknameController {
     public CommonResponse<DeleteBuildingNicknameRes> deleteBuildingNickname(
         @Parameter(name = "nicknameId", description = "건물 별명 ID") @PathVariable Long nicknameId) {
         return CommonResponse.success(adminBuildingNicknameService.deleteBuildingNickname(nicknameId));
+    }
+
+    @GetMapping("/{buildingId}/nicknames")
+    @Operation(summary = "건물 별명 조회",
+        description = "건물 별명 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "건물을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<GetBuildingNicknameListRes> getBuildingNickname(
+        @Parameter(name = "buildingId", description = "건물 ID") @PathVariable Long buildingId) {
+        return CommonResponse.success(adminBuildingNicknameService.getBuildingNickname(buildingId));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
@@ -1,0 +1,41 @@
+package devkor.com.teamcback.domain.admin.building.controller;
+
+import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
+import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
+import devkor.com.teamcback.domain.admin.building.service.AdminBuildingNicknameService;
+import devkor.com.teamcback.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/buildings/nickname")
+public class AdminBuildingNicknameController {
+    private final AdminBuildingNicknameService adminBuildingNicknameService;
+
+    @PostMapping("/{buildingId}")
+    @Operation(summary = "건물 별명 저장",
+        description = "건물 별명 저장")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "건물을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<SaveBuildingNicknameRes> saveBuildingNickname(
+        @Parameter(name = "buildingId", description = "건물 ID") @PathVariable Long buildingId,
+        @Parameter(description = "건물 별명 저장 dto") @RequestBody SaveBuildingNicknameReq req) {
+        return CommonResponse.success(adminBuildingNicknameService.saveBuildingNickname(buildingId, req));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/controller/AdminBuildingNicknameController.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.admin.building.controller;
 
 import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
+import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingNicknameRes;
 import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
 import devkor.com.teamcback.domain.admin.building.service.AdminBuildingNicknameService;
 import devkor.com.teamcback.global.response.CommonResponse;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,11 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/buildings/nickname")
+@RequestMapping("/api/admin/buildings")
 public class AdminBuildingNicknameController {
     private final AdminBuildingNicknameService adminBuildingNicknameService;
 
-    @PostMapping("/{buildingId}")
+    @PostMapping("/{buildingId}/nicknames")
     @Operation(summary = "건물 별명 저장",
         description = "건물 별명 저장")
     @ApiResponses(value = {
@@ -37,5 +39,20 @@ public class AdminBuildingNicknameController {
         @Parameter(name = "buildingId", description = "건물 ID") @PathVariable Long buildingId,
         @Parameter(description = "건물 별명 저장 dto") @RequestBody SaveBuildingNicknameReq req) {
         return CommonResponse.success(adminBuildingNicknameService.saveBuildingNickname(buildingId, req));
+    }
+
+    @DeleteMapping("/nicknames/{nicknameId}")
+    @Operation(summary = "건물 별명 삭제",
+        description = "건물 별명 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "건물 별명을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<DeleteBuildingNicknameRes> deleteBuildingNickname(
+        @Parameter(name = "nicknameId", description = "건물 별명 ID") @PathVariable Long nicknameId) {
+        return CommonResponse.success(adminBuildingNicknameService.deleteBuildingNickname(nicknameId));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/request/SaveBuildingNicknameReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/request/SaveBuildingNicknameReq.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.admin.building.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "저장할 건물 별명")
+@Getter
+public class SaveBuildingNicknameReq {
+    @Schema(description = "건물 별명", example = "우정관")
+    private String nickname;
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/DeleteBuildingImageRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/DeleteBuildingImageRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.building.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/DeleteBuildingNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/DeleteBuildingNicknameRes.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.admin.building.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "건물 별명 삭제 응답 dto")
+@JsonIgnoreProperties
+public class DeleteBuildingNicknameRes {
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingImageRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingImageRes.java
@@ -1,19 +1,19 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.building.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.BuildingImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "건물 내부 사진 검색 응답 dto")
+@Schema(description = "건물 내부 사진 조회 응답 dto")
 @Getter
-public class SearchBuildingImageRes {
+public class GetBuildingImageRes {
     private Long buildingImageId;
     private Long buildingId;
     private String buildingName;
     private Double floor;
     private String image;
 
-    public SearchBuildingImageRes(BuildingImage buildingImage) {
+    public GetBuildingImageRes(BuildingImage buildingImage) {
         this.buildingImageId = buildingImage.getId();
         this.buildingId = buildingImage.getBuilding().getId();
         this.buildingName = buildingImage.getBuilding().getName();

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameListRes.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class GetBuildingNicknameListRes {
     private Long buildingId;
     private String buildingName;
-    private List<GetBuildingNicknameRes> nicknameList = new ArrayList<>();
+    private List<GetBuildingNicknameRes> nicknameList;
 
     public GetBuildingNicknameListRes(Building building, List<GetBuildingNicknameRes> nicknameList) {
         this.buildingId = building.getId();

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameListRes.java
@@ -1,0 +1,21 @@
+package devkor.com.teamcback.domain.admin.building.dto.response;
+
+import devkor.com.teamcback.domain.building.entity.Building;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Schema(description = "건물 별명 조회 응답 dto")
+@Getter
+public class GetBuildingNicknameListRes {
+    private Long buildingId;
+    private String buildingName;
+    private List<GetBuildingNicknameRes> nicknameList = new ArrayList<>();
+
+    public GetBuildingNicknameListRes(Building building, List<GetBuildingNicknameRes> nicknameList) {
+        this.buildingId = building.getId();
+        this.buildingName = building.getName();
+        this.nicknameList = nicknameList;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/GetBuildingNicknameRes.java
@@ -1,0 +1,15 @@
+package devkor.com.teamcback.domain.admin.building.dto.response;
+
+import devkor.com.teamcback.domain.building.entity.BuildingNickname;
+import lombok.Getter;
+
+@Getter
+public class GetBuildingNicknameRes {
+    private Long nicknameId;
+    private String nickname;
+
+    public GetBuildingNicknameRes(BuildingNickname buildingNickname) {
+        nicknameId = buildingNickname.getId();
+        nickname = buildingNickname.getNickname();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/ModifyBuildingImageRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/ModifyBuildingImageRes.java
@@ -1,16 +1,16 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.building.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.BuildingImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "건물 내부 사진 저장 완료")
+@Schema(description = "건물 내부 사진 수정 완료")
 @Getter
-public class SaveBuildingImageRes {
+public class ModifyBuildingImageRes {
     private Long buildingImageId;
     private String imageUrl;
 
-    public SaveBuildingImageRes(BuildingImage buildingImage) {
+    public ModifyBuildingImageRes(BuildingImage buildingImage) {
         this.buildingImageId = buildingImage.getId();
         this.imageUrl = buildingImage.getImage();
     }

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SaveBuildingImageRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SaveBuildingImageRes.java
@@ -1,16 +1,16 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.building.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.BuildingImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "건물 내부 사진 수정 완료")
+@Schema(description = "건물 내부 사진 저장 완료")
 @Getter
-public class ModifyBuildingImageRes {
+public class SaveBuildingImageRes {
     private Long buildingImageId;
     private String imageUrl;
 
-    public ModifyBuildingImageRes(BuildingImage buildingImage) {
+    public SaveBuildingImageRes(BuildingImage buildingImage) {
         this.buildingImageId = buildingImage.getId();
         this.imageUrl = buildingImage.getImage();
     }

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SaveBuildingNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SaveBuildingNicknameRes.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.admin.building.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "건물 별명 저장 완료")
+@JsonIgnoreProperties
+public class SaveBuildingNicknameRes {
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SearchBuildingImageRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/dto/response/SearchBuildingImageRes.java
@@ -1,19 +1,19 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.building.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.BuildingImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "건물 내부 사진 조회 응답 dto")
+@Schema(description = "건물 내부 사진 검색 응답 dto")
 @Getter
-public class GetBuildingImageRes {
+public class SearchBuildingImageRes {
     private Long buildingImageId;
     private Long buildingId;
     private String buildingName;
     private Double floor;
     private String image;
 
-    public GetBuildingImageRes(BuildingImage buildingImage) {
+    public SearchBuildingImageRes(BuildingImage buildingImage) {
         this.buildingImageId = buildingImage.getId();
         this.buildingId = buildingImage.getBuilding().getId();
         this.buildingName = buildingImage.getBuilding().getName();

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingImageService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingImageService.java
@@ -1,15 +1,15 @@
-package devkor.com.teamcback.domain.admin.service;
+package devkor.com.teamcback.domain.admin.building.service;
 
 import static devkor.com.teamcback.global.response.ResultCode.DUPLICATED_BUILDING_IMAGE;
 import static devkor.com.teamcback.global.response.ResultCode.INCORRECT_FLOOR;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING_IMAGE;
 
-import devkor.com.teamcback.domain.admin.dto.response.DeleteBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.ModifyBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.SaveBuildingImageRes;
-import devkor.com.teamcback.domain.admin.dto.response.SearchBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.ModifyBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingImageRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.SearchBuildingImageRes;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.entity.BuildingImage;
 import devkor.com.teamcback.domain.building.repository.BuildingImageRepository;

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
@@ -5,12 +5,15 @@ import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING
 
 import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
 import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingNicknameRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingNicknameListRes;
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingNicknameRes;
 import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.entity.BuildingNickname;
 import devkor.com.teamcback.domain.building.repository.BuildingNicknameRepository;
 import devkor.com.teamcback.domain.building.repository.BuildingRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +43,16 @@ public class AdminBuildingNicknameService {
         buildingNicknameRepository.delete(buildingNickname);
 
         return new DeleteBuildingNicknameRes();
+    }
+
+    @Transactional(readOnly = true)
+    public GetBuildingNicknameListRes getBuildingNickname(Long buildingId) {
+        Building building = findBuilding(buildingId);
+        List<GetBuildingNicknameRes> nicknameList = buildingNicknameRepository.findAllByBuilding(building)
+            .stream().map(buildingNickname -> new GetBuildingNicknameRes(buildingNickname)).toList();
+
+
+        return new GetBuildingNicknameListRes(building, nicknameList);
     }
 
     private Building findBuilding(Long buildingId) {

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
@@ -1,0 +1,36 @@
+package devkor.com.teamcback.domain.admin.building.service;
+
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING;
+
+import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
+import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
+import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.building.entity.BuildingNickname;
+import devkor.com.teamcback.domain.building.repository.BuildingNicknameRepository;
+import devkor.com.teamcback.domain.building.repository.BuildingRepository;
+import devkor.com.teamcback.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminBuildingNicknameService {
+    private final BuildingNicknameRepository buildingNicknameRepository;
+    private final BuildingRepository buildingRepository;
+
+    // 건물 별명 저장
+    @Transactional
+    public SaveBuildingNicknameRes saveBuildingNickname(Long buildingId, SaveBuildingNicknameReq req) {
+        Building building = findBuilding(buildingId);
+        BuildingNickname buildingNickname = new BuildingNickname(building, req.getNickname());
+
+        buildingNicknameRepository.save(buildingNickname);
+
+        return new SaveBuildingNicknameRes();
+    }
+
+    private Building findBuilding(Long buildingId) {
+        return buildingRepository.findById(buildingId).orElseThrow(() -> new GlobalException(NOT_FOUND_BUILDING));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
@@ -45,6 +45,7 @@ public class AdminBuildingNicknameService {
         return new DeleteBuildingNicknameRes();
     }
 
+    // 건물 별명 조회
     @Transactional(readOnly = true)
     public GetBuildingNicknameListRes getBuildingNickname(Long buildingId) {
         Building building = findBuilding(buildingId);

--- a/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/building/service/AdminBuildingNicknameService.java
@@ -1,8 +1,10 @@
 package devkor.com.teamcback.domain.admin.building.service;
 
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING;
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING_NICKNAME;
 
 import devkor.com.teamcback.domain.admin.building.dto.request.SaveBuildingNicknameReq;
+import devkor.com.teamcback.domain.admin.building.dto.response.DeleteBuildingNicknameRes;
 import devkor.com.teamcback.domain.admin.building.dto.response.SaveBuildingNicknameRes;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.entity.BuildingNickname;
@@ -30,7 +32,21 @@ public class AdminBuildingNicknameService {
         return new SaveBuildingNicknameRes();
     }
 
+    // 건물 별명 삭제
+    @Transactional
+    public DeleteBuildingNicknameRes deleteBuildingNickname(Long nicknameId) {
+        BuildingNickname buildingNickname = findBuildingNickname(nicknameId);
+
+        buildingNicknameRepository.delete(buildingNickname);
+
+        return new DeleteBuildingNicknameRes();
+    }
+
     private Building findBuilding(Long buildingId) {
         return buildingRepository.findById(buildingId).orElseThrow(() -> new GlobalException(NOT_FOUND_BUILDING));
+    }
+
+    private BuildingNickname findBuildingNickname(Long buildingNicknameId) {
+        return buildingNicknameRepository.findById(buildingNicknameId).orElseThrow(() -> new GlobalException(NOT_FOUND_BUILDING_NICKNAME));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/controller/AdminClassroomNicknameController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/controller/AdminClassroomNicknameController.java
@@ -1,0 +1,75 @@
+package devkor.com.teamcback.domain.admin.classroom.controller;
+
+import devkor.com.teamcback.domain.admin.classroom.dto.request.SaveClassroomNicknameReq;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.DeleteClassroomNicknameRes;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.GetClassroomNicknameListRes;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.SaveClassroomNicknameRes;
+import devkor.com.teamcback.domain.admin.classroom.service.AdminClassroomNicknameService;
+import devkor.com.teamcback.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/classrooms")
+public class AdminClassroomNicknameController {
+    private final AdminClassroomNicknameService adminClassroomNicknameService;
+
+    @PostMapping("/{classroomId}/nicknames")
+    @Operation(summary = "강의실 별명 저장",
+        description = "강의실 별명 저장")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "강의실을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<SaveClassroomNicknameRes> saveClassroomNickname(
+        @Parameter(name = "classroomId", description = "강의실 ID") @PathVariable Long classroomId,
+        @Parameter(description = "강의실 별명 저장 dto") @RequestBody SaveClassroomNicknameReq req) {
+        return CommonResponse.success(adminClassroomNicknameService.saveClassroomNickname(classroomId, req));
+    }
+
+    @DeleteMapping("/nicknames/{nicknameId}")
+    @Operation(summary = "강의실 별명 삭제",
+        description = "강의실 별명 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "강의실 별명을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<DeleteClassroomNicknameRes> deleteClassroomNickname(
+        @Parameter(name = "nicknameId", description = "강의실 별명 ID") @PathVariable Long nicknameId) {
+        return CommonResponse.success(adminClassroomNicknameService.deleteClassroomNickname(nicknameId));
+    }
+
+    @GetMapping("/{classroomId}/nicknames")
+    @Operation(summary = "강의실 별명 조회",
+        description = "강의실 별명 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "강의실을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<GetClassroomNicknameListRes> getClassroomNickname(
+        @Parameter(name = "classroomId", description = "강의실 ID") @PathVariable Long classroomId) {
+        return CommonResponse.success(adminClassroomNicknameService.getClassroomNickname(classroomId));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/request/SaveClassroomNicknameReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/request/SaveClassroomNicknameReq.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.admin.classroom.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "저장할 강의실 별명")
+@Getter
+public class SaveClassroomNicknameReq {
+    @Schema(description = "강의실 별명", example = "강의준비실")
+    private String nickname;
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/DeleteClassroomNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/DeleteClassroomNicknameRes.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.admin.classroom.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "강의실 별명 삭제 응답 dto")
+@JsonIgnoreProperties
+public class DeleteClassroomNicknameRes {
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/GetClassroomNicknameListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/GetClassroomNicknameListRes.java
@@ -1,0 +1,23 @@
+package devkor.com.teamcback.domain.admin.classroom.dto.response;
+
+import devkor.com.teamcback.domain.admin.building.dto.response.GetBuildingNicknameRes;
+import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.classroom.entity.Classroom;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Schema(description = "강의실 별명 조회 응답 dto")
+@Getter
+public class GetClassroomNicknameListRes {
+    private Long classroomId;
+    private String classroomName;
+    private List<GetClassroomNicknameRes> nicknameList;
+
+    public GetClassroomNicknameListRes(Classroom classroom, List<GetClassroomNicknameRes> nicknameList) {
+        this.classroomId = classroom.getId();
+        this.classroomName = classroom.getName();
+        this.nicknameList = nicknameList;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/GetClassroomNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/GetClassroomNicknameRes.java
@@ -1,0 +1,15 @@
+package devkor.com.teamcback.domain.admin.classroom.dto.response;
+
+import devkor.com.teamcback.domain.classroom.entity.ClassroomNickname;
+import lombok.Getter;
+
+@Getter
+public class GetClassroomNicknameRes {
+    private Long nicknameId;
+    private String nickname;
+
+    public GetClassroomNicknameRes(ClassroomNickname classroomNickname) {
+        nicknameId = classroomNickname.getId();
+        nickname = classroomNickname.getNickname();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/SaveClassroomNicknameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/dto/response/SaveClassroomNicknameRes.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.admin.classroom.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "강의실 별명 저장 완료")
+@JsonIgnoreProperties
+public class SaveClassroomNicknameRes {
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/classroom/service/AdminClassroomNicknameService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/classroom/service/AdminClassroomNicknameService.java
@@ -1,0 +1,66 @@
+package devkor.com.teamcback.domain.admin.classroom.service;
+
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_CLASSROOM;
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_CLASSROOM_NICKNAME;
+
+import devkor.com.teamcback.domain.admin.classroom.dto.request.SaveClassroomNicknameReq;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.DeleteClassroomNicknameRes;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.GetClassroomNicknameListRes;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.GetClassroomNicknameRes;
+import devkor.com.teamcback.domain.admin.classroom.dto.response.SaveClassroomNicknameRes;
+import devkor.com.teamcback.domain.classroom.entity.Classroom;
+import devkor.com.teamcback.domain.classroom.entity.ClassroomNickname;
+import devkor.com.teamcback.domain.classroom.repository.ClassroomNicknameRepository;
+import devkor.com.teamcback.domain.classroom.repository.ClassroomRepository;
+import devkor.com.teamcback.global.exception.GlobalException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminClassroomNicknameService {
+    private final ClassroomNicknameRepository classroomNicknameRepository;
+    private final ClassroomRepository classroomRepository;
+
+    // 강의실 별명 저장
+    @Transactional
+    public SaveClassroomNicknameRes saveClassroomNickname(Long classroomId, SaveClassroomNicknameReq req) {
+        Classroom classroom = findClassroom(classroomId);
+        ClassroomNickname classroomNickname = new ClassroomNickname(classroom, req.getNickname());
+
+        classroomNicknameRepository.save(classroomNickname);
+
+        return new SaveClassroomNicknameRes();
+    }
+
+    // 강의실 별명 삭제
+    @Transactional
+    public DeleteClassroomNicknameRes deleteClassroomNickname(Long nicknameId) {
+        ClassroomNickname classroomNickname = findClassroomNickname(nicknameId);
+
+        classroomNicknameRepository.delete(classroomNickname);
+
+        return new DeleteClassroomNicknameRes();
+    }
+
+    // 강의실 별명 조회
+    @Transactional(readOnly = true)
+    public GetClassroomNicknameListRes getClassroomNickname(Long classroomId) {
+        Classroom classroom = findClassroom(classroomId);
+        List<GetClassroomNicknameRes> nicknameList = classroomNicknameRepository.findAllByClassroom(classroom)
+            .stream().map(classroomNickname -> new GetClassroomNicknameRes(classroomNickname)).toList();
+
+
+        return new GetClassroomNicknameListRes(classroom, nicknameList);
+    }
+
+    private Classroom findClassroom(Long classroomId) {
+        return classroomRepository.findById(classroomId).orElseThrow(() -> new GlobalException(NOT_FOUND_CLASSROOM));
+    }
+
+    private ClassroomNickname findClassroomNickname(Long nicknameId) {
+        return classroomNicknameRepository.findById(nicknameId).orElseThrow(() -> new GlobalException(NOT_FOUND_CLASSROOM_NICKNAME));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/controller/AdminRouteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/controller/AdminRouteController.java
@@ -1,13 +1,13 @@
-package devkor.com.teamcback.domain.admin.controller;
+package devkor.com.teamcback.domain.admin.route.controller;
 
-import devkor.com.teamcback.domain.admin.dto.request.CreateNodeReq;
-import devkor.com.teamcback.domain.admin.dto.request.ModifyNodeReq;
-import devkor.com.teamcback.domain.admin.dto.response.CreateNodeRes;
-import devkor.com.teamcback.domain.admin.dto.response.DeleteNodeRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetNodeDetailRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetNodeListRes;
-import devkor.com.teamcback.domain.admin.dto.response.ModifyNodeRes;
-import devkor.com.teamcback.domain.admin.service.AdminRouteService;
+import devkor.com.teamcback.domain.admin.route.dto.request.CreateNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.request.ModifyNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.response.CreateNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.DeleteNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.GetNodeDetailRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.GetNodeListRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.ModifyNodeRes;
+import devkor.com.teamcback.domain.admin.route.service.AdminRouteService;
 import devkor.com.teamcback.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/request/CreateNodeReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/request/CreateNodeReq.java
@@ -1,13 +1,13 @@
-package devkor.com.teamcback.domain.admin.dto.request;
+package devkor.com.teamcback.domain.admin.route.dto.request;
 
 import devkor.com.teamcback.domain.navigate.entity.NodeType;
-import devkor.com.teamcback.domain.admin.validation.CommaNumeric;
+import devkor.com.teamcback.domain.admin.route.validation.CommaNumeric;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "수정할 노드 정보")
+@Schema(description = "저장할 노드 정보")
 @Getter
-public class ModifyNodeReq {
+public class CreateNodeReq {
     @Schema(description = "노드 타입", example = "NORMAL")
     private NodeType type;
     @Schema(description = "x좌표", example = "0.0")

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/request/ModifyNodeReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/request/ModifyNodeReq.java
@@ -1,13 +1,13 @@
-package devkor.com.teamcback.domain.admin.dto.request;
+package devkor.com.teamcback.domain.admin.route.dto.request;
 
 import devkor.com.teamcback.domain.navigate.entity.NodeType;
-import devkor.com.teamcback.domain.admin.validation.CommaNumeric;
+import devkor.com.teamcback.domain.admin.route.validation.CommaNumeric;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "저장할 노드 정보")
+@Schema(description = "수정할 노드 정보")
 @Getter
-public class CreateNodeReq {
+public class ModifyNodeReq {
     @Schema(description = "노드 타입", example = "NORMAL")
     private NodeType type;
     @Schema(description = "x좌표", example = "0.0")

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/CreateNodeRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/CreateNodeRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import devkor.com.teamcback.domain.navigate.entity.Node;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/DeleteNodeRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/DeleteNodeRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeDetailRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import devkor.com.teamcback.domain.classroom.entity.Classroom;
 import devkor.com.teamcback.domain.facility.entity.Facility;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeListRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.entity.BuildingImage;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/GetNodeRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import devkor.com.teamcback.domain.navigate.entity.Node;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/ModifyNodeRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/dto/response/ModifyNodeRes.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.dto.response;
+package devkor.com.teamcback.domain.admin.route.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/service/AdminRouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/service/AdminRouteService.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.service;
+package devkor.com.teamcback.domain.admin.route.service;
 
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_NODE;
@@ -11,14 +11,14 @@ import devkor.com.teamcback.domain.classroom.entity.Classroom;
 import devkor.com.teamcback.domain.classroom.repository.ClassroomRepository;
 import devkor.com.teamcback.domain.facility.entity.Facility;
 import devkor.com.teamcback.domain.facility.repository.FacilityRepository;
-import devkor.com.teamcback.domain.admin.dto.request.CreateNodeReq;
-import devkor.com.teamcback.domain.admin.dto.request.ModifyNodeReq;
-import devkor.com.teamcback.domain.admin.dto.response.CreateNodeRes;
-import devkor.com.teamcback.domain.admin.dto.response.DeleteNodeRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetNodeDetailRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetNodeListRes;
-import devkor.com.teamcback.domain.admin.dto.response.GetNodeRes;
-import devkor.com.teamcback.domain.admin.dto.response.ModifyNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.request.CreateNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.request.ModifyNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.response.CreateNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.DeleteNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.GetNodeDetailRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.GetNodeListRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.GetNodeRes;
+import devkor.com.teamcback.domain.admin.route.dto.response.ModifyNodeRes;
 import devkor.com.teamcback.domain.navigate.entity.Node;
 import devkor.com.teamcback.domain.navigate.repository.NodeRepository;
 import devkor.com.teamcback.global.exception.GlobalException;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/validation/CommaNumeric.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/validation/CommaNumeric.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.validation;
+package devkor.com.teamcback.domain.admin.route.validation;
 
 import jakarta.validation.Constraint;
 import java.lang.annotation.ElementType;

--- a/src/main/java/devkor/com/teamcback/domain/admin/route/validation/CommaNumericValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/admin/route/validation/CommaNumericValidator.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.admin.validation;
+package devkor.com.teamcback.domain.admin.route.validation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingNicknameRepository.java
@@ -1,5 +1,6 @@
 package devkor.com.teamcback.domain.building.repository;
 
+import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.entity.BuildingNickname;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ public interface BuildingNicknameRepository extends JpaRepository<BuildingNickna
     List<BuildingNickname> findByNicknameContaining(String word);
 
     BuildingNickname findByNickname(String nickname);
+
+    List<BuildingNickname> findAllByBuilding(Building building);
 }

--- a/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
@@ -1,9 +1,13 @@
 package devkor.com.teamcback.domain.classroom.repository;
 
+import devkor.com.teamcback.domain.classroom.entity.Classroom;
 import devkor.com.teamcback.domain.classroom.entity.ClassroomNickname;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClassroomNicknameRepository extends JpaRepository<ClassroomNickname, Long> {
     List<ClassroomNickname> findByNicknameContaining(String word);
+
+    List<ClassroomNickname> findAllByClassroom(Classroom classroom);
 }

--- a/src/main/java/devkor/com/teamcback/domain/navigate/entity/Node.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/entity/Node.java
@@ -2,8 +2,8 @@ package devkor.com.teamcback.domain.navigate.entity;
 
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.common.BaseEntity;
-import devkor.com.teamcback.domain.admin.dto.request.CreateNodeReq;
-import devkor.com.teamcback.domain.admin.dto.request.ModifyNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.request.CreateNodeReq;
+import devkor.com.teamcback.domain.admin.route.dto.request.ModifyNodeReq;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -28,6 +28,7 @@ public enum ResultCode {
     DUPLICATED_BUILDING_IMAGE(HttpStatus.CONFLICT, 3002, "해당 건물의 층의 이미지가 이미 존재합니다."),
     INCORRECT_FLOOR(HttpStatus.BAD_REQUEST, 3003, "건물에 존재하지 않는 층입니다."),
     NOT_FOUND_BUILDING_IMAGE(HttpStatus.NOT_FOUND, 3004, "존재하지 않는 건물 사진입니다."),
+    NOT_FOUND_BUILDING_NICKNAME(HttpStatus.NOT_FOUND, 3005, "건물 별명을 찾을 수 없습니다."),
 
     // 강의실 4000번대
     NOT_FOUND_CLASSROOM(HttpStatus.NOT_FOUND, 4000, "강의실을 찾을 수 없습니다."),

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -32,6 +32,7 @@ public enum ResultCode {
 
     // 강의실 4000번대
     NOT_FOUND_CLASSROOM(HttpStatus.NOT_FOUND, 4000, "강의실을 찾을 수 없습니다."),
+    NOT_FOUND_CLASSROOM_NICKNAME(HttpStatus.NOT_FOUND, 4001, "강의실 별명을 찾을 수 없습니다."),
 
     // 편의시설 5000번대
     NOT_FOUND_FACILITY(HttpStatus.NOT_FOUND, 5000, "편의시설을 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
강의실, 건물 별명의 추가, 삭제, 조회 api입니다.

## 작업사항
- 관리자용 api 디렉터리 수정
- 건물 내부 사진 url 수정
- 건물 별명 추가, 삭제, 조회
- 강의실 별명 추가, 삭제, 조회

## 관련 이슈
- close #20 
