### PR TITLE
Fix: maskIndex null값도 반환하도록 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetRoomDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetRoomDetailRes.java
@@ -8,16 +8,18 @@ import devkor.com.teamcback.domain.facility.entity.FacilityType;
 import lombok.Getter;
 
 @Getter
-@JsonInclude(Include.NON_NULL)
 public class GetRoomDetailRes {
     private String type;
     private Long id;
+    @JsonInclude(Include.NON_NULL)
     private FacilityType facilityType;
     private String name;
     private String detail;
+    @JsonInclude(Include.NON_NULL)
     private boolean availability;
     private boolean plugAvailability;
     private String imageUrl;
+    @JsonInclude(Include.NON_NULL)
     private String operatingTime;
     private Double longitude;
     private Double latitude;
@@ -48,7 +50,7 @@ public class GetRoomDetailRes {
         this.availability = facility.isAvailability();
         this.plugAvailability = facility.isPlugAvailability();
         this.imageUrl = facility.getImageUrl();
-        this.operatingTime = facility.getImageUrl();
+        this.operatingTime = facility.getOperatingTime();
         this.longitude = facility.getNode().getLongitude();
         this.latitude = facility.getNode().getLatitude();
         this.xCoord = facility.getNode().getXCoord();


### PR DESCRIPTION
## 개요
maskIndex null값도 반환하도록 수정

## 작업사항
- 전체에 적용되어 있던 @JsonInclude(Include.NON_NULL)을 maskIndex만 제외하고 공통되지 않는 필드 위에 각각 추가했습니다!
- 추가로 아래에 operatingTime 이 imageUrl로 들어가있길래 수정했습니다..!

## 관련 이슈
- 
