### PR TITLE
Search API 수정 & 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
@@ -227,11 +227,11 @@ public class CategoryService {
     }
 
     public void checkPlaceExists(PlaceType placeType, Long placeId) {
-        if ("BUILDING".equals(placeType.name()) && !buildingRepository.existsById(placeId)) {
+        if (PlaceType.BUILDING.equals(placeType) && !buildingRepository.existsById(placeId)) {
             throw new GlobalException(NOT_FOUND_BUILDING);
-        } else if ("CLASSROOM".equals(placeType.name()) && !classroomRepository.existsById(placeId)) {
+        } else if (PlaceType.CLASSROOM.equals(placeType) && !classroomRepository.existsById(placeId)) {
             throw new GlobalException(NOT_FOUND_CLASSROOM);
-        } else if ("FACILITY".equals(placeType.name()) && !facilityRepository.existsById(placeId)) {
+        } else if (PlaceType.FACILITY.equals(placeType) && !facilityRepository.existsById(placeId)) {
             throw new GlobalException(NOT_FOUND_FACILITY);
         }
     }

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -188,7 +188,7 @@ public class SearchController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @GetMapping("/place/{placeId}")
+    @GetMapping("/place/{placeId}/mask")
     public CommonResponse<SearchMaskIndexByPlaceRes> searchMaskIndexByPlace(
         @Parameter(name = "placeId", description = "classroom_id 또는 facility_id", example = "1", required = true)
         @PathVariable Long placeId,
@@ -214,10 +214,32 @@ public class SearchController {
         @AuthenticationPrincipal UserDetailsImpl userDetail,
         @Parameter(name = "buildingId", description = "건물 id", example = "1", required = true)
         @PathVariable Long buildingId) {
-
         Long userId = (userDetail != null) ? userDetail.getUser().getUserId() : null;
         return CommonResponse.success(searchService.searchBuildingDetail(userId, buildingId));
+    }
 
+    /**
+     * 장소(교실, 편의시설) 상세 정보 조회
+     * @param placeType 장소 종류
+     * @param placeId 장소 id
+     * @param userDetail 사용자 정보
+     */
+    @Operation(summary = "장소(교실 or 시설) 상세 정보 조회", description = "장소(교실 or 시설) 상세 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "Not Found",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @GetMapping("/place/{placeId}")
+    public CommonResponse<SearchPlaceDetailRes> searchPlaceDetail(
+        @Parameter(description = "사용자정보", required = false)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(name = "placeId", description = "classroom_id 또는 facility_id", example = "1", required = true)
+        @PathVariable Long placeId,
+        @Parameter(name = "placeType", description = "CLASSROOM 또는 FACILITY", example = "CLASSROOM", required = true)
+        @RequestParam PlaceType placeType) {
+        Long userId = (userDetail != null) ? userDetail.getUser().getUserId() : null;
+        return CommonResponse.success(searchService.searchPlaceDetail(userId, placeId, placeType));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -178,6 +178,26 @@ public class SearchController {
     }
 
     /**
+     * place 대응 Mask Index 반환
+     * @param placeId 장소 id
+     * @param placeType 장소 종류
+     */
+    @Operation(summary = "Mask Index 대응 교실 조회", description = "Room의 mask index에 대응되는 교실 id를 반환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "Not Found",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @GetMapping("/place/{placeId}")
+    public CommonResponse<SearchMaskIndexByPlaceRes> searchMaskIndexByPlace(
+        @Parameter(name = "placeId", description = "classroom_id 또는 facility_id", example = "1", required = true)
+        @PathVariable Long placeId,
+        @Parameter(name = "placeType", description = "CLASSROOM 또는 FACILITY", example = "CLASSROOM", required = true)
+        @RequestParam PlaceType placeType) {
+        return CommonResponse.success(searchService.searchMaskIndexByPlace(placeId, placeType));
+    }
+
+    /**
      * 건물 상세 정보 조회
      * @param buildingId 건물 id
      * @param userDetail 사용자 정보

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetBuildingDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetBuildingDetailRes.java
@@ -39,7 +39,7 @@ public class GetBuildingDetailRes {
 
     public GetBuildingDetailRes(Building building, List<FacilityType> facilityTypes) {
         this.buildingId = building.getId();
-        this.name = building.getName();
+        this.name = "고려대학교 서울캠퍼스 " + building.getName();
         this.imageUrl = building.getImageUrl();
         this.detail = building.getDetail();
         this.address = building.getAddress();
@@ -49,10 +49,10 @@ public class GetBuildingDetailRes {
         this.latitude = building.getNode().getLatitude();
         this.floor = building.getFloor();
         this.underFloor = building.getUnderFloor();
+        this.facilityTypes = facilityTypes;
         //TODO: 차후 isOperating, nextOperatingTime 수정하기(현재 임시값)
         this.isOperating = true;
-        this.nextBuildingTime = "10:00";
-        this.facilityTypes = facilityTypes;
+        this.nextBuildingTime = "22:00";
 
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetBuildingDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GetBuildingDetailRes.java
@@ -1,7 +1,10 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
 import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.facility.entity.FacilityType;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class GetBuildingDetailRes {
@@ -16,6 +19,9 @@ public class GetBuildingDetailRes {
     private Double latitude;
     private Double floor;
     private Double underFloor;
+    private boolean isOperating;
+    private String nextBuildingTime; // 현재 열려있으면 닫는 시간, 닫혀있으면 다음으로 여는 시간 반환
+    private List<FacilityType> facilityTypes;
 
     public GetBuildingDetailRes(Building building) {
         this.buildingId = building.getId();
@@ -29,5 +35,24 @@ public class GetBuildingDetailRes {
         this.latitude = building.getNode().getLatitude();
         this.floor = building.getFloor();
         this.underFloor = building.getUnderFloor();
+    }
+
+    public GetBuildingDetailRes(Building building, List<FacilityType> facilityTypes) {
+        this.buildingId = building.getId();
+        this.name = building.getName();
+        this.imageUrl = building.getImageUrl();
+        this.detail = building.getDetail();
+        this.address = building.getAddress();
+        this.operatingTime = building.getOperatingTime();
+        this.needStudentCard = building.getNeedStudentCard();
+        this.longitude = building.getNode().getLongitude();
+        this.latitude = building.getNode().getLatitude();
+        this.floor = building.getFloor();
+        this.underFloor = building.getUnderFloor();
+        //TODO: 차후 isOperating, nextOperatingTime 수정하기(현재 임시값)
+        this.isOperating = true;
+        this.nextBuildingTime = "10:00";
+        this.facilityTypes = facilityTypes;
+
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingDetailRes.java
@@ -16,6 +16,10 @@ public class SearchBuildingDetailRes {
     private String name;
     @Schema(description = "주소", example = "서울 성북구 안암로 73-15")
     private String address;
+    @Schema(description = "건물 사진 url", example = "buildingurlurl")
+    private String imageUrl;
+    @Schema(description = "운영 시간", example = "9:00-22:00")
+    private String operatingTime;
     @Schema(description = "건물 정보(TMI)", example = "애기능생활관이다.")
     private String details;
     @Schema(description = "북마크 저장 여부", example = "false")
@@ -24,14 +28,23 @@ public class SearchBuildingDetailRes {
     private List<FacilityType> existTypes; //건물 내 facility 종류 리스트(아이콘용)
     @Schema(description = "주요 시설 리스트")
     private List<GetMainFacilityRes> mainFacilityList;
+    @Schema(description = "운영 여부", example = "false")
+    private boolean isOperating;
+    @Schema(description = "현재 열려있으면 닫는 시간, 닫혀있으면 다음으로 여는 시간 반환", example = "9:00")
+    private String nextBuildingTime; // 현재 열려있으면 닫는 시간, 닫혀있으면 다음으로 여는 시간 반환
 
     public SearchBuildingDetailRes(List<GetMainFacilityRes> facilities, List<FacilityType> types, Building building, boolean bookmarked) {
         this.buildingId = building.getId();
         this.name = "고려대학교 서울캠퍼스 " + building.getName();
         this.address = building.getAddress();
+        this.imageUrl = building.getImageUrl();
+        this.operatingTime = building.getOperatingTime();
         this.details = building.getDetail();
         this.bookmarked = bookmarked;
         this.existTypes = types;
         this.mainFacilityList = facilities;
+        //TODO: 차후 isOperating, nextOperatingTime 수정하기(현재 임시값)
+        this.isOperating = false;
+        this.nextBuildingTime = "9:00";
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchMaskIndexByPlaceRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchMaskIndexByPlaceRes.java
@@ -1,0 +1,30 @@
+package devkor.com.teamcback.domain.search.dto.response;
+
+import devkor.com.teamcback.domain.classroom.entity.Classroom;
+import devkor.com.teamcback.domain.facility.entity.Facility;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "장소 대응 maskIndex 정보")
+public class SearchMaskIndexByPlaceRes {
+    @Schema(description = "Mask Index", example = "1")
+    private Integer maskIndex;
+    @Schema(description = "건물 Id", example = "1")
+    private Long buildingId;
+    @Schema(description = "건물 층", example = "1")
+    private int floor;
+
+    public SearchMaskIndexByPlaceRes(Classroom classroom) {
+        this.maskIndex = classroom.getMaskIndex();
+        this.buildingId = classroom.getBuilding().getId();
+        this.floor = classroom.getFloor().intValue();
+    }
+    public SearchMaskIndexByPlaceRes(Facility facility) {
+        this.maskIndex = facility.getMaskIndex();
+        this.buildingId = facility.getBuilding().getId();
+        this.floor = facility.getFloor().intValue();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
@@ -1,0 +1,72 @@
+package devkor.com.teamcback.domain.search.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import devkor.com.teamcback.domain.classroom.entity.Classroom;
+import devkor.com.teamcback.domain.common.PlaceType;
+import devkor.com.teamcback.domain.facility.entity.Facility;
+import devkor.com.teamcback.domain.facility.entity.FacilityType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SearchPlaceDetailRes {
+    private PlaceType type;
+    private Long id;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private FacilityType facilityType;
+    private String name;
+    private String detail;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private boolean availability;  //사용 가능 여부
+    private boolean plugAvailability;
+    private String imageUrl;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String operatingTime;
+    private Double longitude;
+    private Double latitude;
+    private double xCoord;
+    private double yCoord;
+    private Integer maskIndex;
+    private boolean bookmarked;
+    private boolean isOperating;
+    private String nextPlaceTime;
+    public SearchPlaceDetailRes(Classroom classroom, boolean bookmarked) {
+        this.type = PlaceType.CLASSROOM;
+        this.id = classroom.getId();
+        this.name = classroom.getName();
+        this.detail = classroom.getDetail();
+        this.plugAvailability = classroom.isPlugAvailability();
+        this.imageUrl = classroom.getImageUrl();
+        this.longitude = classroom.getNode().getLongitude();
+        this.latitude = classroom.getNode().getLatitude();
+        this.xCoord = classroom.getNode().getXCoord();
+        this.yCoord = classroom.getNode().getYCoord();
+        this.maskIndex = classroom.getMaskIndex();
+        this.bookmarked = bookmarked;
+        //TODO: 나중에 운영 정보 수정해서 넣기
+        this.isOperating = true;
+        this.nextPlaceTime = "22:00";
+    }
+
+    public SearchPlaceDetailRes(Facility facility, boolean bookmarked) {
+        this.type = PlaceType.FACILITY;
+        this.id = facility.getId();
+        this.facilityType = facility.getType();
+        this.name = facility.getName();
+        this.detail = facility.getDetail();
+        this.availability = facility.isAvailability();
+        this.plugAvailability = facility.isPlugAvailability();
+        this.imageUrl = facility.getImageUrl();
+        this.operatingTime = facility.getOperatingTime();
+        this.longitude = facility.getNode().getLongitude();
+        this.latitude = facility.getNode().getLatitude();
+        this.xCoord = facility.getNode().getXCoord();
+        this.yCoord = facility.getNode().getYCoord();
+        this.maskIndex = facility.getMaskIndex();
+        this.bookmarked = bookmarked;
+        //TODO: 나중에 운영 정보 수정해서 넣기
+        this.isOperating = false;
+        this.nextPlaceTime = "9:00";
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
@@ -31,17 +31,22 @@ public class SearchPlaceDetailRes {
     private boolean bookmarked;
     private boolean isOperating;
     private String nextPlaceTime;
+
     public SearchPlaceDetailRes(Classroom classroom, boolean bookmarked) {
         this.type = PlaceType.CLASSROOM;
         this.id = classroom.getId();
-        this.name = classroom.getName();
+        if(classroom.getBuilding().getId() == 0) {
+            this.name = classroom.getName();
+            this.longitude = classroom.getNode().getLongitude();
+            this.latitude = classroom.getNode().getLatitude();
+        } else {
+            this.name = classroom.getBuilding().getName() + " " + classroom.getName();
+            this.xCoord = classroom.getNode().getXCoord();
+            this.yCoord = classroom.getNode().getYCoord();
+        }
         this.detail = classroom.getDetail();
         this.plugAvailability = classroom.isPlugAvailability();
         this.imageUrl = classroom.getImageUrl();
-        this.longitude = classroom.getNode().getLongitude();
-        this.latitude = classroom.getNode().getLatitude();
-        this.xCoord = classroom.getNode().getXCoord();
-        this.yCoord = classroom.getNode().getYCoord();
         this.maskIndex = classroom.getMaskIndex();
         this.bookmarked = bookmarked;
         //TODO: 나중에 운영 정보 수정해서 넣기
@@ -53,16 +58,20 @@ public class SearchPlaceDetailRes {
         this.type = PlaceType.FACILITY;
         this.id = facility.getId();
         this.facilityType = facility.getType();
-        this.name = facility.getName();
+        if(facility.getBuilding().getId() == 0) {
+            this.name = facility.getName();
+            this.longitude = facility.getNode().getLongitude();
+            this.latitude = facility.getNode().getLatitude();
+        } else {
+            this.name = facility.getBuilding().getName() + " " + facility.getName();
+            this.xCoord = facility.getNode().getXCoord();
+            this.yCoord = facility.getNode().getYCoord();
+        }
         this.detail = facility.getDetail();
         this.availability = facility.isAvailability();
         this.plugAvailability = facility.isPlugAvailability();
         this.imageUrl = facility.getImageUrl();
         this.operatingTime = facility.getOperatingTime();
-        this.longitude = facility.getNode().getLongitude();
-        this.latitude = facility.getNode().getLatitude();
-        this.xCoord = facility.getNode().getXCoord();
-        this.yCoord = facility.getNode().getYCoord();
         this.maskIndex = facility.getMaskIndex();
         this.bookmarked = bookmarked;
         //TODO: 나중에 운영 정보 수정해서 넣기

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -30,8 +30,7 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_BUILDING;
-import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
+import static devkor.com.teamcback.global.response.ResultCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -245,6 +244,23 @@ public class SearchService {
     }
 
     /**
+     * 교실 대응 Mask Index 조회
+     */
+    @Transactional(readOnly = true)
+    public SearchMaskIndexByPlaceRes searchMaskIndexByPlace(Long placeId, PlaceType type) {
+        SearchMaskIndexByPlaceRes res = new SearchMaskIndexByPlaceRes();
+        switch (type) {
+            case CLASSROOM -> {
+                res = new SearchMaskIndexByPlaceRes(findClassroom(placeId));
+            }
+            case FACILITY -> {
+                res =  new SearchMaskIndexByPlaceRes(findFacility(placeId));
+            }
+        }
+        return res;
+    }
+
+    /**
      * 건물 상세 정보 조회
      */
     @Transactional(readOnly = true)
@@ -328,5 +344,11 @@ public class SearchService {
 
     private Building findBuilding(Long buildingId) {
         return buildingRepository.findById(buildingId).orElseThrow(() -> new GlobalException(NOT_FOUND_BUILDING));
+    }
+    private Classroom findClassroom(Long classroomId) {
+        return classroomRepository.findById(classroomId).orElseThrow(() -> new GlobalException(NOT_FOUND_CLASSROOM));
+    }
+    private Facility findFacility(Long facilityId) {
+        return facilityRepository.findById(facilityId).orElseThrow(() -> new GlobalException(NOT_FOUND_FACILITY));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -108,7 +108,23 @@ public class SearchService {
     @Transactional(readOnly = true)
     public SearchBuildingRes searchAllBuildings() {
         List<Building> buildingList = buildingRepository.findAll();
-        return new SearchBuildingRes(buildingList.stream().filter(building -> building.getId() != 0).map(GetBuildingDetailRes::new).toList());
+        List<GetBuildingDetailRes> res = new ArrayList<>();
+
+        // 각 건물에 존재하는 편의시설 타입 추가 (건물 모달)
+        // 자판기, 프린터, 라운지, 열람실, 스터디룸, 카페, 편의점, 식당, 수면실, 샤워실, 은행, 헬스장
+        List<FacilityType> iconTypes = Arrays.asList(FacilityType.VENDING_MACHINE, FacilityType.PRINTER, FacilityType.LOUNGE, FacilityType.READING_ROOM, FacilityType.STUDY_ROOM, FacilityType.CAFE, FacilityType.CONVENIENCE_STORE, FacilityType.CAFETERIA, FacilityType.SLEEPING_ROOM, FacilityType.SHOWER_ROOM, FacilityType.BANK, FacilityType.GYM);
+
+        return new SearchBuildingRes(
+            buildingList.stream()
+            .filter(building -> building.getId() != 0)
+            .map(building -> {
+                List<FacilityType> containFacilityTypes = getFacilitiesByBuildingAndTypes(building, iconTypes).stream()
+                    .map(Facility::getType)
+                    .distinct()
+                    .toList();
+                return new GetBuildingDetailRes(building, containFacilityTypes);
+            })
+            .collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -302,6 +302,42 @@ public class SearchService {
         return new SearchBuildingDetailRes(res, containFacilityTypes, building, bookmarked);
     }
 
+    /**
+     * 장소(교실, 편의시설) 상세 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public SearchPlaceDetailRes searchPlaceDetail(Long userId, Long placeId, PlaceType placeType) {
+        SearchPlaceDetailRes res = new SearchPlaceDetailRes();
+        List<Category> categories = new ArrayList<>();
+        boolean bookmarked = false;
+
+        //즐겨찾기 여부 확인용 정보 가져오기
+        if(userId != null) {
+            User user = findUser(userId);
+            categories = categoryRepository.findAllByUser(user);
+        }
+
+        switch (placeType) {
+            case CLASSROOM -> {
+                Classroom classroom = findClassroom(placeId);
+                if(bookmarkRepository.existsByPlaceTypeAndPlaceIdAndCategoryIn(PlaceType.CLASSROOM, classroom.getId(), categories)) {
+                    bookmarked = true;
+                }
+                res = new SearchPlaceDetailRes(classroom, bookmarked);
+            }
+            case FACILITY -> {
+                Facility facility = findFacility(placeId);
+                if(bookmarkRepository.existsByPlaceTypeAndPlaceIdAndCategoryIn(PlaceType.FACILITY, facility.getId(), categories)) {
+                    bookmarked = true;
+                }
+                res =  new SearchPlaceDetailRes(facility, bookmarked);
+            }
+        }
+
+        // TODO: 운영시간 정보, 운영여부 t/f 나중에 넣기 (운영시간 완성되면)
+        return res;
+    }
+
     private List<Facility> getFacilitiesByBuildingAndTypes(Building building, List<FacilityType> types) {
         return facilityRepository.findAllByBuildingAndTypeInOrderByFloor(building, types);
     }


### PR DESCRIPTION
## 작업사항
1. 전체 빌딩 조회
    -> 건물 이름 수정, 운영 정보(임시값), 편의시설 타입 추가
    +) nextBuildingTime : 현재 열려있으면 닫는 시간, 닫혀있으면 다음으로 여는 시간 반환하는 것으로 구상하였습니다. 

2. 건물 상세 정보 조회
    ->건물 사진 url, 운영 정보(임시값) 추가

3. placeType, placeId를 받은 후 건물id, 층, mask Index를 반환하는 API 추가

4. 장소(교실 or 편의시설) 상세 정보 조회 API 추가
    -> placeType과 placeId를 입력하면 상세 정보 조회 가능
    -> bookmarked 여부 확인 가능
    -> 운영 정보(임시값) 추가, nextPlaceTime은 위의 nextBuildingTime과 동일
    ->실내면 건물명+장소명, 야외면 장소명만 반환