### PR TITLE
fix 길찾기 기능 수정 및 보수

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/navigate/controller/RouteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/controller/RouteController.java
@@ -39,7 +39,6 @@ public class RouteController {
      * @param endId (endType이 COORD가 아닌 경우) 도착 시설 id
      * @param endLat (endType이 COORD인 경우) 도착 위도
      * @param endLong (endType이 COORD인 경우) 도착 경도
-     * @param barrierFree barrierFree 여부(ELEVATOR, STAIR의 경우 해당 노드 이용 X)
      *
      */
     @GetMapping()
@@ -50,7 +49,7 @@ public class RouteController {
         @ApiResponse(responseCode = "404", description = "Not Found",
         content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    public CommonResponse<GetRouteRes> findRoute(
+    public CommonResponse<List<GetRouteRes>> findRoute(
         @Parameter(name = "startType", description = "출발 장소의 LocationType", example = "CLASSROOM", required = true)
         @RequestParam LocationType startType,
         @Parameter(name = "startId", description = "startType이 COORD가 아닐 경우 해당 시설의 ID")
@@ -66,9 +65,7 @@ public class RouteController {
         @Parameter(name = "endLat", description = "endType이 COORD일 경우 해당 장소의 위도")
         @RequestParam(required = false) Double endLat,
         @Parameter(name = "endLong", description = "endType이 COORD일 경우 해당 장소의 경도")
-        @RequestParam(required = false) Double endLong,
-        @Parameter(name = "barrierFree", description = "STAIR 또는 ELEVATOR, 이용하지 않을 이동수단")
-        @RequestParam(required = false)NodeType barrierFree) throws ParseException {
+        @RequestParam(required = false) Double endLong) throws ParseException {
         List<Double> startLocation = new ArrayList<>();
         List<Double> endLocation = new ArrayList<>();
 
@@ -84,7 +81,9 @@ public class RouteController {
         else{
             endLocation.add(endId.doubleValue());
         }
-
-        return CommonResponse.success(routeService.findRoute(startLocation, startType, endLocation, endType, barrierFree));
+        List<GetRouteRes> returnList = new ArrayList<>();
+        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, null));
+        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, NodeType.STAIR));
+        return CommonResponse.success(returnList);
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/navigate/dto/response/GetRouteRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/dto/response/GetRouteRes.java
@@ -10,11 +10,18 @@ public class GetRouteRes {
     private Long duration;
     @Schema(description = "상세 경로")
     private List<PartialRouteRes> path;
+    @Schema(description = "경로 관련 오류사항")
+    private String description;
 
     public GetRouteRes(Long duration, List<PartialRouteRes> path){
         this.duration = duration;
         this.path = path;
     }
+
+    public GetRouteRes(String description){
+        this.description = description;
+    }
+
     public void addPath(PartialRouteRes path){
         this.path.add(path);
     }

--- a/src/main/java/devkor/com/teamcback/domain/navigate/entity/LinkedBuildingData.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/entity/LinkedBuildingData.java
@@ -14,6 +14,8 @@ public class LinkedBuildingData {
         ...
          필요에 따라 위와 같은 식으로 다른 건물들의 연결 정보 추가
         */
+        linkedBuildings.put(15L, List.of(13L));
+        linkedBuildings.put(13L, List.of(15L));
     }
 
     public static List<Long> getLinkedBuildings(Long buildingId) {

--- a/src/main/java/devkor/com/teamcback/domain/navigate/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/navigate/service/RouteService.java
@@ -67,7 +67,7 @@ public class RouteService {
         List<Building> buildingList = getBuildingsForRoute(startNode, endNode);
         GetGraphRes graphRes = getGraph(buildingList, startNode, endNode, barrierFree);
         DijkstraRes route = dijkstra(graphRes.getGraphNode(), graphRes.getGraphEdge(), startNode, endNode);
-
+        if (route.getPath().isEmpty()) return new GetRouteRes("제공되는 경로가 없습니다.");
         return buildRouteResponse(route, isStartBuilding, isEndBuilding);
     }
 
@@ -181,8 +181,14 @@ public class RouteService {
             graphNode.add(endNode);
         }
         for (Node node: graphNode){
+            String rawAdjacentNode = node.getAdjacentNode();
+            String rawDistance = node.getDistance();
+            //추후 수정이 필요할 코드(에러핸들링)
+            if (rawAdjacentNode == null || rawDistance == null) continue;
             String[] endNodeId = node.getAdjacentNode().split(",");
             String[] distance = node.getDistance().split(",");
+            //if (endNodeId.length != distance.length) throw new Error("노드"+node.getId()+"에 형식의 문제가 있습니다.");
+            if (endNodeId.length != distance.length) continue;
 
             for (int i = 0; i < endNodeId.length; i++) {
                 // 시작끝 모두 Long으로 써서 경로 찾은 후, 해당 경로 대해서만 node 찾기


### PR DESCRIPTION
## 개요
길찾기 기능 수정 및 보수

## 작업사항
*경로가 찾아지지 않을 경우 오류 메시지를 담게 리턴되도록 GetRouteRes 기능 추가
*RouteController의 파라미터에서 barrierFree 제거. 대신, 아예 그냥 탐색과 계단 이용 안 한 barrierFree 경로로 2개의 경로가 리턴되도록 RouteController 수정
*노드 데이터가 들어간 것 확인된 하나스퀘어와 과학도서관 연결 정보 LinkedBuildingData에 등록, 경로 탐색 원활한 것 확인
*getGraph 수정, 이제 인접 노드가 없어도(adjacentNode나 distance가 null이어도) 경로 탐색 가능. 추가적으로, adjacentNode와 distance의 길이가 다른 경우에도 일단 길찾기에 이용하지 않도록 수정. 주석 달린 코드 통해 그와 관련된 오류 있는지 확인 가능.

## 관련 이슈
- route api 리턴 형식 변경: path가 이제는 경로 묶음의 리스트를 리턴합니다.
