### PR TITLE
운영시간 오류 및 강의실 검색 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
@@ -4,6 +4,7 @@ import devkor.com.teamcback.domain.common.BaseEntity;
 import devkor.com.teamcback.domain.navigate.entity.Node;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -46,7 +47,7 @@ public class Building extends BaseEntity {
     @Column(nullable = false)
     private Double underFloor;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id")
     private Node node;
 

--- a/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
@@ -1,9 +1,12 @@
 package devkor.com.teamcback.domain.building.repository;
 
 import devkor.com.teamcback.domain.building.entity.Building;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
     Building findBuildingById(long id);
+
+    List<Building> findAllByIdNotIn(List<Long> buildingIdList);
 }

--- a/src/main/java/devkor/com/teamcback/domain/classroom/entity/Classroom.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/entity/Classroom.java
@@ -44,7 +44,7 @@ public class Classroom extends BaseEntity {
     @JoinColumn(name = "building_id")
     private Building building;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id")
     private Node node;
 

--- a/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
@@ -10,4 +10,6 @@ public interface ClassroomNicknameRepository extends JpaRepository<ClassroomNick
     List<ClassroomNickname> findByNicknameContaining(String word);
 
     List<ClassroomNickname> findAllByClassroom(Classroom classroom);
+
+    List<ClassroomNickname> findByNicknameContainingAndClassroomIn(String word, List<Classroom> list);
 }

--- a/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomRepository.java
@@ -13,4 +13,6 @@ public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
 
     Classroom findByBuildingAndFloorAndMaskIndex(Building building, double floor, Integer maskIndex);
     Classroom findByNode(Node node);
+
+    List<Classroom> findAllByIdNotIn(List<Long> classroomIdList);
 }

--- a/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomRepository.java
@@ -15,4 +15,6 @@ public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
     Classroom findByNode(Node node);
 
     List<Classroom> findAllByIdNotIn(List<Long> classroomIdList);
+
+    List<Classroom> findAllByBuilding(Building building);
 }

--- a/src/main/java/devkor/com/teamcback/domain/facility/entity/Facility.java
+++ b/src/main/java/devkor/com/teamcback/domain/facility/entity/Facility.java
@@ -49,7 +49,7 @@ public class Facility extends BaseEntity {
     @JoinColumn(name = "building_id")
     private Building building;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id")
     private Node node;
 

--- a/src/main/java/devkor/com/teamcback/domain/facility/repository/FacilityRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/facility/repository/FacilityRepository.java
@@ -32,4 +32,6 @@ public interface FacilityRepository extends JpaRepository<Facility, Long> {
     List<Facility> findAllByBuildingAndTypeInOrderByFloor(Building building, List<FacilityType> types);
 
     List<Facility> findAllByBuildingAndNameContaining(Building building, String word);
+
+    List<Facility> findAllByIdNotIn(List<Long> facilityIdList);
 }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -33,8 +33,8 @@ public class OperatingScheduler {
     private static Boolean isVacation = null;
     private static Boolean isEvenWeek = null;
 
-//    @Scheduled(cron = "0 * * * * *") // 테스트용
-    @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
+    @Scheduled(cron = "0 * * * * *") // 테스트용 1분마다
+//    @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
     public void updateOperatingTime() {
         log.info("운영 시간 업데이트");
         LocalDate now = LocalDate.now();
@@ -55,8 +55,8 @@ public class OperatingScheduler {
         operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
-//    @Scheduled(cron = "*/20 * * * * *") // 테스트용
-    @Scheduled(cron = "0 0,30 1-23 * * *") // 매일 30분마다 (자정 제외)
+    @Scheduled(cron = "*/30 * * * * *") // 테스트용 30초마다
+//    @Scheduled(cron = "0 0,30 * * * *") // 매일 30분마다
     public void updateIsOperating() {
         log.info("운영 여부 업데이트");
         LocalDateTime nowTime = LocalDateTime.now();

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -33,8 +33,8 @@ public class OperatingScheduler {
     private static Boolean isVacation = null;
     private static Boolean isEvenWeek = null;
 
-    @Scheduled(cron = "0 * * * * *") // 테스트용 1분마다
-//    @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
+//    @Scheduled(cron = "0 * * * * *") // 테스트용 1분마다
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
     public void updateOperatingTime() {
         log.info("운영 시간 업데이트");
         LocalDate now = LocalDate.now();
@@ -55,8 +55,8 @@ public class OperatingScheduler {
         operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
-    @Scheduled(cron = "*/30 * * * * *") // 테스트용 30초마다
-//    @Scheduled(cron = "0 0,30 * * * *") // 매일 30분마다
+//    @Scheduled(cron = "*/30 * * * * *") // 테스트용 30초마다
+    @Scheduled(cron = "0 0,30 * * * *") // 매일 30분마다
     public void updateIsOperating() {
         log.info("운영 여부 업데이트");
         LocalDateTime nowTime = LocalDateTime.now();


### PR DESCRIPTION
## 개요
운영 조건에 포함되지 않는 시설의 운영 여부가 바뀌지 않는 오류 수정했습니다.

## 작업사항
- 운영 조건에 포함되지 않는 건물의 운영 여부는 false로, 강의실과 편의시설은 건물의 운영여부를 따라가도록 수정
- 운영 시간 스케줄러가 돌아갈 때 노드까지 검색되어 오래 걸리는 문제를 해결하기 위해 건물/강의실/편의시설이 노드를 지연로딩하도록 변경 -> 기존 api들이 정상적으로 돌아가는지 확인했으나 문제가 생길 수 있습니다...
- 강의실 검색 시 '검색어가 포함되는 별명 검색 -> 건물과 일치하는지 확인' 부분이 오래 걸리는 것 같아 '건물에 해당하는 강의실 검색 -> 강의실과 검색어를 포함하는 별명 검색' 순서로 변경하였습니다.

## 관련 이슈
- 
