### PR TITLE
통합검색 기능 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/classroom/repository/ClassroomNicknameRepository.java
@@ -4,12 +4,14 @@ import devkor.com.teamcback.domain.classroom.entity.Classroom;
 import devkor.com.teamcback.domain.classroom.entity.ClassroomNickname;
 import java.util.Collection;
 import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClassroomNicknameRepository extends JpaRepository<ClassroomNickname, Long> {
-    List<ClassroomNickname> findByNicknameContaining(String word);
+    List<ClassroomNickname> findByNicknameContaining(String word, Pageable pageable);
 
     List<ClassroomNickname> findAllByClassroom(Classroom classroom);
 
-    List<ClassroomNickname> findByNicknameContainingAndClassroomIn(String word, List<Classroom> list);
+    List<ClassroomNickname> findByNicknameContainingAndClassroomIn(String word, List<Classroom> list,  Pageable pageable);
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -28,23 +28,20 @@ public class SearchController {
 
     /***
      * keyword가 포함된 장소 검색
-     * @param buildingId 건물 ID
      * @param keyword 검색 단어
      *
      */
     @GetMapping()
-    @Operation(summary = "입력 통한 후보 검색어 조회", description = "keyword가 포함된 장소 조회. 건물 Id가 없으면 전체 검색, 있으면 해당 건물에 속한 시설 검색")
+    @Operation(summary = "입력 통한 후보 검색어 조회", description = "keyword가 포함된 장소 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<GlobalSearchListRes> globalSearch(
-        @Parameter(name = "building_id", description = "태그화된 건물의 ID(생략 가능)", example = "1", required = false)
-        @RequestParam(name = "building_id", required = false) Long buildingId,
         @Parameter(name = "keyword", description = "검색 키워드", example = "애기능", required = true)
         @RequestParam(name = "keyword") String keyword) {
-        return CommonResponse.success(searchService.globalSearch(buildingId, keyword));
+        return CommonResponse.success(searchService.globalSearch(keyword));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -28,11 +28,32 @@ public class SearchController {
 
     /***
      * keyword가 포함된 장소 검색
+     * @param buildingId 건물 ID
      * @param keyword 검색 단어
      *
      */
     @GetMapping()
-    @Operation(summary = "입력 통한 후보 검색어 조회", description = "keyword가 포함된 장소 조회")
+    @Operation(summary = "입력 통한 후보 검색어 조회 (태그O)", description = "keyword가 포함된 장소 조회. 건물 Id가 없으면 전체 검색, 있으면 해당 건물에 속한 시설 검색")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "Not Found",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<GlobalSearchListRes> globalSearch(
+        @Parameter(name = "building_id", description = "태그화된 건물의 ID(생략 가능)", example = "1", required = false)
+        @RequestParam(name = "building_id", required = false) Long buildingId,
+        @Parameter(name = "keyword", description = "검색 키워드", example = "애기능", required = true)
+        @RequestParam(name = "keyword") String keyword) {
+        return CommonResponse.success(searchService.globalSearch(buildingId, keyword));
+    }
+
+    /***
+     * keyword가 포함된 장소 검색
+     * @param keyword 검색 단어
+     *
+     */
+    @GetMapping("/test")
+    @Operation(summary = "입력 통한 후보 검색어 조회 (태그X)", description = "keyword가 포함된 장소 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
         @ApiResponse(responseCode = "404", description = "Not Found",
@@ -41,7 +62,7 @@ public class SearchController {
     public CommonResponse<GlobalSearchListRes> globalSearch(
         @Parameter(name = "keyword", description = "검색 키워드", example = "애기능", required = true)
         @RequestParam(name = "keyword") String keyword) {
-        return CommonResponse.success(searchService.globalSearch(keyword));
+        return CommonResponse.success(searchService.globalSearchTest(keyword));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -23,6 +23,9 @@ import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,43 +59,51 @@ public class SearchService {
      * 검색어 자동 완성
      */
     @Transactional(readOnly = true)
-    public GlobalSearchListRes globalSearch(Long buildingId, String word) {
+    public GlobalSearchListRes globalSearch(String word) {
         List<GlobalSearchRes> list = new ArrayList<>();
 
         List<Classroom> classrooms;
         List<Facility> facilities;
+        List<Building> buildings;
 
-        // 먼저 검색한 건물이 있을 때
-        if(buildingId != null) {
-            Building building = findBuilding(buildingId);
-            facilities = getFacilities(word, building);
-            classrooms = getClassrooms(word, building);
+        // 건물이 입력됨
+        if(word.contains(" ")) {
+            String candidateBuilding = word.split(" ")[0];
+            String placeWord = word.substring(candidateBuilding.length()).trim();
 
-            for(Classroom classroom : classrooms) {
-                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
-            }
-            for(Facility facility : facilities) {
-                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
-            }
-        }
+            buildings = getBuildings(candidateBuilding);
 
-        else {
-            List<Building> buildings = getBuildings(word);
-            facilities = getFacilities(word, null);
-            classrooms = getClassrooms(word, null);
+            if (!buildings.isEmpty()) { //building이 존재하는 경우
+                for (Building building : buildings) {
+                    facilities = getFacilities(placeWord, building);
+                    classrooms = getClassrooms(placeWord, building);
 
-            for(Building building : buildings) {
-                list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
-            }
-            for(Classroom classroom : classrooms) {
-                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
-            }
-            for(Facility facility : facilities) {
-                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
+                    for (Classroom classroom : classrooms) {
+                        list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
+                    }
+                    for (Facility facility : facilities) {
+                        list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
+                    }
+                }
+                return new GlobalSearchListRes(orderSequence(list, word, candidateBuilding));
             }
         }
 
-        return new GlobalSearchListRes(list);
+        buildings = getBuildings(word);
+        facilities = getFacilities(word, null);
+        classrooms = getClassrooms(word, null);
+
+        for(Building building : buildings) {
+            list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
+        }
+        for(Classroom classroom : classrooms) {
+            list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
+        }
+        for(Facility facility : facilities) {
+            list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
+        }
+
+        return new GlobalSearchListRes(orderSequence(list, word, null));
     }
 
     /**
@@ -342,19 +353,69 @@ public class SearchService {
             .toList();
     }
 
+    private List<GlobalSearchRes> orderSequence(List<GlobalSearchRes> list, String keyword, String buildingKeyword) {
+        Map<GlobalSearchRes, Integer> scores = new HashMap<>();
+        // 강의실, 특수명 편의시설은 baseScore = 0
+        int baseScore = 0;
+        int indexScore = 0;
+
+        for (GlobalSearchRes res : list) {
+            if (res.getPlaceType() == PlaceType.BUILDING) {
+                baseScore = 1000;
+                indexScore = buildingKeyword != null ? calculateScoreByIndex(res.getName(), buildingKeyword) : calculateScoreByIndex(res.getName(), keyword);
+            }
+            if (res.getPlaceType() == PlaceType.FACILITY) {
+                if(checkFacilityType(res.getName())) {
+                    baseScore = 500;
+                }
+                indexScore = calculateScoreByIndex(res.getName(), keyword);
+            }
+            if (res.getPlaceType() == PlaceType.CLASSROOM) {
+                indexScore = calculateScoreByIndex(res.getName(), keyword);
+            }
+            scores.put(res, baseScore + indexScore);
+        }
+
+        return scores.entrySet().stream()
+            .sorted(Map.Entry.<GlobalSearchRes, Integer>comparingByValue().reversed())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+    }
+
+    public static boolean checkFacilityType(String name) {
+        return Arrays.stream(FacilityType.values())
+            .anyMatch(facilityType -> facilityType.getName().equals(name));
+    }
+
+    private int calculateScoreByIndex(String name, String keyword) {
+        int indexScore = 0;
+        String[] bracketWords = name.split("\\(", 2);
+        for (char c : keyword.toCharArray()) {
+            int index;
+            // 괄호 내부 값에 대해 더 높은 가중치 부여
+            index = (name.contains("(") && bracketWords[1].contains(String.valueOf(c))) ? bracketWords[1].indexOf(c) : name.indexOf(c);
+
+            if (index != -1) indexScore += (100 - index);
+        }
+        return indexScore;
+    }
+
     private List<Classroom> getClassrooms(String word, Building building) {
         List<Classroom> classrooms = new ArrayList<>();
         if(building != null) {
             classrooms = classroomRepository.findAllByBuilding(building);
         }
 
+        //응답 개수 제한
+        Pageable limit = PageRequest.of(0, 30, Sort.by("id").descending());
+
         // 강의실 조회
         List<ClassroomNickname> classroomNicknames = new ArrayList<>();
         if(building != null && !classrooms.isEmpty()) {
-            classroomNicknames = classroomNicknameRepository.findByNicknameContainingAndClassroomIn(word, classrooms);
+            classroomNicknames = classroomNicknameRepository.findByNicknameContainingAndClassroomIn(word, classrooms, limit);
         }
         else if(building == null) {
-            classroomNicknames = classroomNicknameRepository.findByNicknameContaining(word);
+            classroomNicknames = classroomNicknameRepository.findByNicknameContaining(word, limit);
         }
 
 

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -59,7 +59,50 @@ public class SearchService {
      * 검색어 자동 완성
      */
     @Transactional(readOnly = true)
-    public GlobalSearchListRes globalSearch(String word) {
+    public GlobalSearchListRes globalSearch(Long buildingId, String word) {
+        List<GlobalSearchRes> list = new ArrayList<>();
+
+        List<Classroom> classrooms;
+        List<Facility> facilities;
+
+        // 먼저 검색한 건물이 있을 때
+        if(buildingId != null) {
+            Building building = findBuilding(buildingId);
+            facilities = getFacilities(word, building);
+            classrooms = getClassrooms(word, building);
+
+            for(Classroom classroom : classrooms) {
+                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
+            }
+            for(Facility facility : facilities) {
+                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
+            }
+        }
+
+        else {
+            List<Building> buildings = getBuildings(word);
+            facilities = getFacilities(word, null);
+            classrooms = getClassrooms(word, null);
+
+            for(Building building : buildings) {
+                list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
+            }
+            for(Classroom classroom : classrooms) {
+                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
+            }
+            for(Facility facility : facilities) {
+                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY));
+            }
+        }
+
+        return new GlobalSearchListRes(list);
+    }
+
+    /**
+     * 검색어 자동 완성
+     */
+    @Transactional(readOnly = true)
+    public GlobalSearchListRes globalSearchTest(String word) {
         List<GlobalSearchRes> list = new ArrayList<>();
 
         List<Classroom> classrooms;

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -365,12 +365,11 @@ public class SearchService {
                 indexScore = buildingKeyword != null ? calculateScoreByIndex(res.getName(), buildingKeyword) : calculateScoreByIndex(res.getName(), keyword);
             }
             if (res.getPlaceType() == PlaceType.FACILITY) {
-                if(checkFacilityType(res.getName())) {
-                    baseScore = 500;
-                }
+                baseScore = checkFacilityType(res.getName()) ? 500 : 0;
                 indexScore = calculateScoreByIndex(res.getName(), keyword);
             }
             if (res.getPlaceType() == PlaceType.CLASSROOM) {
+                baseScore = 0;
                 indexScore = calculateScoreByIndex(res.getName(), keyword);
             }
             scores.put(res, baseScore + indexScore);


### PR DESCRIPTION
<수정사항>

* 공백 기준 첫번째 값을 건물로 받아서 검색하도록 수정

* 검색 결과 가중치 수정 (Score 사용)
-빌딩 → 1000점
-편의시설(type리스트에 있으면)→500점
-편의시설(리스트X) → 0점
-강의실→0점

~> (100 - 첫 글자가 등장하는 위치 index) 를 각각 더해서 최종 점수 도출 (+괄호 내부의 값에 대해 가중치 부여)

* 검색 결과 개수 제한 추가
-한글자만 입력 시 DB가 커짐에 따라 시간이 매우 많이 소요됨 (첫 글자 입력 후 항상 오랜 시간이 소요)
-building 제외 classroom의 경우 DB에서부터 30개씩만 가져오도록 제한

<API>
- 기존의 것 포함
- 새로운 통합 검색은 /search/test 로 수정했습니다.