### PR TITLE
통합 검색 기능 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/facility/entity/Facility.java
+++ b/src/main/java/devkor/com/teamcback/domain/facility/entity/Facility.java
@@ -68,6 +68,12 @@ public class Facility extends BaseEntity {
         this.node = node;
     }
 
+    public Facility(FacilityType type, Building building) {
+        this.type = type;
+        this.name = type.getName();
+        this.building = building;
+    }
+
     public void update(ModifyFacilityReq req, Building building, Node node) {
         this.type = req.getType();
         this.name = req.getName();

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -28,31 +28,10 @@ public class SearchController {
 
     /***
      * keyword가 포함된 장소 검색
-     * @param buildingId 건물 ID
      * @param keyword 검색 단어
      *
      */
     @GetMapping()
-    @Operation(summary = "입력 통한 후보 검색어 조회 (태그O)", description = "keyword가 포함된 장소 조회. 건물 Id가 없으면 전체 검색, 있으면 해당 건물에 속한 시설 검색")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
-        @ApiResponse(responseCode = "404", description = "Not Found",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-    })
-    public CommonResponse<GlobalSearchListRes> globalSearch(
-        @Parameter(name = "building_id", description = "태그화된 건물의 ID(생략 가능)", example = "1", required = false)
-        @RequestParam(name = "building_id", required = false) Long buildingId,
-        @Parameter(name = "keyword", description = "검색 키워드", example = "애기능", required = true)
-        @RequestParam(name = "keyword") String keyword) {
-        return CommonResponse.success(searchService.globalSearch(buildingId, keyword));
-    }
-
-    /***
-     * keyword가 포함된 장소 검색
-     * @param keyword 검색 단어
-     *
-     */
-    @GetMapping("/test")
     @Operation(summary = "입력 통한 후보 검색어 조회 (태그X)", description = "keyword가 포함된 장소 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
@@ -62,7 +41,7 @@ public class SearchController {
     public CommonResponse<GlobalSearchListRes> globalSearch(
         @Parameter(name = "keyword", description = "검색 키워드", example = "애기능", required = true)
         @RequestParam(name = "keyword") String keyword) {
-        return CommonResponse.success(searchService.globalSearchTest(keyword.trim()));
+        return CommonResponse.success(searchService.globalSearch(keyword.trim()));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
@@ -37,6 +37,20 @@ public class GlobalSearchRes {
     @Schema(description = "building_id", example = "null/0/1")
     private Long buildingId;
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GlobalSearchRes that = (GlobalSearchRes) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
     public GlobalSearchRes(Building building, PlaceType placeType) {
         this.id = building.getId();
         this.name = building.getName();

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/GlobalSearchRes.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GlobalSearchRes {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     @Schema(description = "건물 또는 시설 id", example = "1")
     private Long id;
     @Schema(description = "건물 또는 시설 이름", example = "애기능생활관")
@@ -32,6 +33,9 @@ public class GlobalSearchRes {
     private PlaceType placeType;
     @Schema(description = "편의시설 종류", example = "LOUNGE")
     private FacilityType facilityType;
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @Schema(description = "building_id", example = "null/0/1")
+    private Long buildingId;
 
     public GlobalSearchRes(Building building, PlaceType placeType) {
         this.id = building.getId();
@@ -59,11 +63,17 @@ public class GlobalSearchRes {
     }
 
     public GlobalSearchRes(Facility facility, PlaceType placeType, boolean hasBuilding) {
-        this.id = facility.getId();
-
-        if (facility.getBuilding().getId() == 0 || (facility.getType().getName().equals(facility.getName()) && !hasBuilding)) {
+        if(!hasBuilding && facility.getType().getName().equals(facility.getName())) { //야외태그
+            this.id = null;
+            this.buildingId = 0L;
             this.name = facility.getName();
-        } else {
+        } else if (hasBuilding && facility.getType().getName().equals(facility.getName())) { //내부태그
+            this.id = null;
+            this.buildingId = facility.getBuilding().getId();
+            this.name = facility.getBuilding().getName() + " " + facility.getName();
+        } else { //특정 시설
+            this.id = facility.getId();
+            this.buildingId = null;
             this.name = facility.getBuilding().getName() + " " + facility.getName();
         }
         this.placeType = placeType;

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -61,6 +61,7 @@ public class SearchService {
     @Transactional(readOnly = true)
     public GlobalSearchListRes globalSearch(String word) {
         List<GlobalSearchRes> list = new ArrayList<>();
+        Map<GlobalSearchRes, Integer> scores = new HashMap<>();
 
         List<Classroom> classrooms;
         List<Facility> facilities;
@@ -68,27 +69,21 @@ public class SearchService {
 
         // 건물이 입력됨
         if(word.contains(" ")) {
-            String candidateBuilding = word.split(" ")[0];
-            String placeWord = word.substring(candidateBuilding.length()).trim();
+            String firstBuildingWord = word.split(" ")[0];
+            String lastBuildingWord = word.split(" ")[word.split(" ").length - 1];
+            String firstPlaceWord = word.substring(firstBuildingWord.length()).trim();
+            String lastPlaceWord = word.substring(0, word.length() - lastBuildingWord.length()).trim();
 
-            buildings = getBuildings(candidateBuilding);
-
-            if (!buildings.isEmpty()) { //building이 존재하는 경우
-                for (Building building : buildings) {
-                    list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
-                    facilities = getFacilities(placeWord, building);
-                    classrooms = getClassrooms(placeWord, building);
-
-                    for (Classroom classroom : classrooms) {
-                        list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
-                    }
-                    for (Facility facility : facilities) {
-                        list.add(new GlobalSearchRes(facility, PlaceType.FACILITY, true));
-                    }
-                }
-
-                return new GlobalSearchListRes(orderSequence(list, word, candidateBuilding));
+            buildings = getBuildings(firstBuildingWord);
+            if(!buildings.isEmpty()) {
+                scores.putAll(getScores(word, buildings, firstPlaceWord, firstBuildingWord));
             }
+
+            buildings = getBuildings(lastBuildingWord);
+            if(!buildings.isEmpty()) {
+                scores.putAll(getScores(word, buildings, lastPlaceWord, lastBuildingWord));
+            }
+            return new GlobalSearchListRes(orderSequence(scores));
         }
 
         buildings = getBuildings(word);
@@ -105,7 +100,7 @@ public class SearchService {
             list.add(new GlobalSearchRes(facility, PlaceType.FACILITY, false));
         }
 
-        return new GlobalSearchListRes(orderSequence(list, word, null));
+        return new GlobalSearchListRes(orderSequence(calculateScore(list, word, null)));
     }
 
     /**
@@ -355,7 +350,27 @@ public class SearchService {
             .toList();
     }
 
-    private List<GlobalSearchRes> orderSequence(List<GlobalSearchRes> list, String keyword, String buildingKeyword) {
+    private Map<GlobalSearchRes, Integer> getScores(String word, List<Building> buildings, String placeWord, String buildingWord) {
+        List<GlobalSearchRes> list = new ArrayList<>();
+        List<Classroom> classrooms;
+        List<Facility> facilities;
+
+        for (Building building : buildings) {
+            list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
+            facilities = getFacilities(placeWord, building);
+            classrooms = getClassrooms(placeWord, building);
+
+            for (Classroom classroom : classrooms) {
+                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
+            }
+            for (Facility facility : facilities) {
+                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY, true));
+            }
+        }
+        return calculateScore(list, word, buildingWord);
+    }
+
+    private Map<GlobalSearchRes, Integer> calculateScore(List<GlobalSearchRes> list, String keyword, String buildingKeyword) {
         //TODO : 로그인 반영 후, 즐겨찾기 여부 확인해서 맨 위로 올리기 -> baseScore = 5000
         Map<GlobalSearchRes, Integer> scores = new HashMap<>();
         // 강의실, 특수명 편의시설은 baseScore = 0
@@ -368,17 +383,23 @@ public class SearchService {
                 indexScore = buildingKeyword != null ? calculateScoreByIndex(res.getName(), buildingKeyword) : calculateScoreByIndex(res.getName(), keyword);
             }
             if (res.getPlaceType() == PlaceType.FACILITY) {
-                baseScore = checkFacilityType(res.getName()) ? 500 : 0;
+                if(res.getName().contains(" ")) {
+                    baseScore = checkFacilityType(res.getName().split(" ", 2)[1]) ? 500 : 0;
+                } else {
+                    baseScore = 500;
+                }
                 indexScore = calculateScoreByIndex(res.getName(), keyword);
             }
             if (res.getPlaceType() == PlaceType.CLASSROOM) {
                 baseScore = 0;
                 indexScore = calculateScoreByIndex(res.getName(), keyword);
             }
-            System.out.println(res.getName() + " 점수점수: " + baseScore+indexScore);
             scores.put(res, baseScore + indexScore);
         }
+        return scores;
+    }
 
+    private static List<GlobalSearchRes> orderSequence(Map<GlobalSearchRes, Integer> scores) {
         // 점수를 기준으로 그룹화
         Map<Integer, List<GlobalSearchRes>> groupedByScore = scores.entrySet().stream()
             .collect(Collectors.groupingBy(

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -75,6 +75,7 @@ public class SearchService {
 
             if (!buildings.isEmpty()) { //building이 존재하는 경우
                 for (Building building : buildings) {
+                    list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
                     facilities = getFacilities(placeWord, building);
                     classrooms = getClassrooms(placeWord, building);
 
@@ -355,7 +356,7 @@ public class SearchService {
     }
 
     private List<GlobalSearchRes> orderSequence(List<GlobalSearchRes> list, String keyword, String buildingKeyword) {
-        //TODO : 로그인 반영 후, 즐겨찾기 여부 확인해서 맨 위로 올리기
+        //TODO : 로그인 반영 후, 즐겨찾기 여부 확인해서 맨 위로 올리기 -> baseScore = 5000
         Map<GlobalSearchRes, Integer> scores = new HashMap<>();
         // 강의실, 특수명 편의시설은 baseScore = 0
         int baseScore = 0;
@@ -363,7 +364,7 @@ public class SearchService {
 
         for (GlobalSearchRes res : list) {
             if (res.getPlaceType() == PlaceType.BUILDING) {
-                baseScore = 1000;
+                baseScore = buildingKeyword == null ? 1000 : -500;
                 indexScore = buildingKeyword != null ? calculateScoreByIndex(res.getName(), buildingKeyword) : calculateScoreByIndex(res.getName(), keyword);
             }
             if (res.getPlaceType() == PlaceType.FACILITY) {
@@ -374,6 +375,7 @@ public class SearchService {
                 baseScore = 0;
                 indexScore = calculateScoreByIndex(res.getName(), keyword);
             }
+            System.out.println(res.getName() + " 점수점수: " + baseScore+indexScore);
             scores.put(res, baseScore + indexScore);
         }
 
@@ -408,15 +410,23 @@ public class SearchService {
     }
 
     private int calculateScoreByIndex(String name, String keyword) {
+        // 괄호() > 대학 > 관 (앞의 것이 존재한다면 해당 것을 기준으로 삼음)
+        String[] criteria = {"\\(", "대학", "관"};
         int indexScore = 0;
-        String[] bracketWords = name.split("\\(", 2);
-        for (char c : keyword.toCharArray()) {
-            int index;
-            // 괄호 내부 값에 대해 더 높은 가중치 부여
-            index = (name.contains("(") && bracketWords[1].contains(String.valueOf(c))) ? bracketWords[1].indexOf(c) : name.indexOf(c);
 
-            if (index != -1) indexScore += (100 - index);
+        for (String c : criteria) {
+            if(name.contains(c.replace("\\", ""))) {
+                String[] temp = name.split(c, 2);
+                if(!temp[1].isEmpty()) {
+                    name = temp[1];
+                    break;
+                }
+            }
         }
+
+        int index = name.indexOf(keyword.charAt(0));
+        if (index != -1) indexScore += (100 - index);
+
         return indexScore;
     }
 

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -56,53 +56,10 @@ public class SearchService {
         FacilityType.SLEEPING_ROOM, FacilityType.SHOWER_ROOM, FacilityType.BANK, FacilityType.GYM);
 
     /**
-     * 검색어 자동 완성
+     * 통합 검색
      */
     @Transactional(readOnly = true)
-    public GlobalSearchListRes globalSearch(Long buildingId, String word) {
-        List<GlobalSearchRes> list = new ArrayList<>();
-
-        List<Classroom> classrooms;
-        List<Facility> facilities;
-
-        // 먼저 검색한 건물이 있을 때
-        if(buildingId != null) {
-            Building building = findBuilding(buildingId);
-            facilities = getFacilities(word, building);
-            classrooms = getClassrooms(word, building);
-
-            for(Classroom classroom : classrooms) {
-                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
-            }
-            for(Facility facility : facilities) {
-                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY, true));
-            }
-        }
-
-        else {
-            List<Building> buildings = getBuildings(word);
-            facilities = getFacilities(word, null);
-            classrooms = getClassrooms(word, null);
-
-            for(Building building : buildings) {
-                list.add(new GlobalSearchRes(building, PlaceType.BUILDING));
-            }
-            for(Classroom classroom : classrooms) {
-                list.add(new GlobalSearchRes(classroom, PlaceType.CLASSROOM));
-            }
-            for(Facility facility : facilities) {
-                list.add(new GlobalSearchRes(facility, PlaceType.FACILITY, false));
-            }
-        }
-
-        return new GlobalSearchListRes(list);
-    }
-
-    /**
-     * 검색어 자동 완성
-     */
-    @Transactional(readOnly = true)
-    public GlobalSearchListRes globalSearchTest(String word) {
+    public GlobalSearchListRes globalSearch(String word) {
         List<GlobalSearchRes> list = new ArrayList<>();
 
         List<Classroom> classrooms;


### PR DESCRIPTION
## 작업사항
1. URL 수정 (/search로 변경), 기존 검색 로직 삭제

 2. GlobalSearchRes DTO 수정
-야외태그(Ex. 라운지) → id = null, buildingId = 0
-내부태그(Ex. 과학도서관 라운지) → id = null, buildingId = 건물ID
-특정시설(Ex. 우당교양관 우당 박종구 라운지) → id = 편의시설ID, buildingId = null
+) id, buildingId는 null이어도 반환하도록 수정

3. 검색 기준에 괄호 외에도 “대학”, “관” 추가 → 생명과학관서관 등도 위에 뜨게 됨

4. 건물명이 맨 뒤에 오는 경우에도 검색 가능
→검색 결과 중복 문제 -> equals(), hashCode() 메서드 오버라이딩

5. 검색 시 항상 건물 포함
→ 건물명 외의 키워드가 존재하는 경우, 건물은 맨 밑에 뜨도록 수정

## 수정사항
- 키워드에 공백이 있는 경우, 공백 기준 둘 모두를 검색하여 indexScore을 계산하도록 수정
- static final 상수 추가
- 특수명 Facility만 가진 경우의 내부 태그 검색을 위한 검색어도 나오도록 수정 (Ex. 이전→ 해송법학도서관 라운지는 나오지 않음)