### PR TITLE
특정 편의시설 리스트 조회

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -66,17 +66,20 @@ public class SearchController {
     }
 
     /**
-     * 모든 건물 검색
+     * 모든 or 편의시설이 있는 건물 검색
      */
     @GetMapping("/buildings")
-    @Operation(summary = "모든 건물 조회 결과", description = "모든 건물의 상세 정보 조회")
+    @Operation(summary = "건물 조회 결과", description = "건물의 상세 정보 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    public CommonResponse<SearchBuildingListRes> searchAllBuildings() {
-        return CommonResponse.success(searchService.searchAllBuildings());
+    public CommonResponse<SearchBuildingListRes> searchBuildings(
+        @Parameter(name = "type", description = "검색하는 편의시설 종류가 있는 건물을 검색하는 경우", example = "TRASH_CAN")
+        @RequestParam(name = "type", required = false) FacilityType facilityType
+    ) {
+        return CommonResponse.success(searchService.searchBuildings(facilityType));
     }
 
     /**
@@ -91,7 +94,7 @@ public class SearchController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    public CommonResponse<SearchFacilityListRes> searchBuildingFacilityByType(
+    public CommonResponse<SearchBuildingFacilityListRes> searchBuildingFacilityByType(
         @Parameter(name = "buildingId", description = "편의시설이 위치한 건물 id", example = "1", required = true)
         @PathVariable Long buildingId,
         @Parameter(name = "type", description = "찾고자 하는 편의시설 종류", example = "TRASH_CAN", required = true)
@@ -137,18 +140,18 @@ public class SearchController {
     }
 
     /**
-     * 편의시설이 있는 건물
+     * 특정 편의시설 리스트
      * @param facilityType 편의시설 종류
      */
-    @Operation(summary = "특정 종류의 편의시설이 있는 건물 내역 조회", description = "특정 종류의 편의시설이 있는 건물 내역 상세 조회")
+    @Operation(summary = "특정 종류의 편의시설 목록 조회", description = "특정 종류의 편의시설 목록 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
     })
     @GetMapping("/facilities")
-    public CommonResponse<SearchBuildingListRes> searchBuildingWithFacilityType(
-        @Parameter(name = "type", description = "검색하는 편의시설 종류", example = "TRASH_CAN", required = true)
+    public CommonResponse<SearchFacilityListRes> searchFacilitiesWithType(
+        @Parameter(name = "type", description = "검색하는 편의시설 종류", example = "CAFE", required = true)
         @RequestParam(name = "type") FacilityType facilityType) {
-        return CommonResponse.success(searchService.searchBuildingWithFacilityType(facilityType));
+        return CommonResponse.success(searchService.searchFacilitiesWithType(facilityType));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingFacilityListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingFacilityListRes.java
@@ -1,0 +1,30 @@
+package devkor.com.teamcback.domain.search.dto.response;
+
+import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.facility.entity.FacilityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "특정 건물의 편의시설 조회 결과")
+@Getter
+public class SearchBuildingFacilityListRes {
+    @Schema(description = "편의시설이 위치한 건물 ID", example = "1")
+    private Long buildingId;
+    @Schema(description = "편의시설이 위치한 건물 이름", example = "애기능생활관")
+    private String buildingName;
+    @Schema(description = "편의시설 종류", example = "TRASH_CAN")
+    private FacilityType type;
+    @Schema(description = "각 층별 편의시설 조회 결과")
+    @Setter
+    private Map<Double, List<SearchFacilityRes>> facilities = new HashMap<>();
+
+    public SearchBuildingFacilityListRes(Building building, FacilityType type) {
+        this.buildingId = building.getId();
+        this.buildingName = building.getName();
+        this.type = type;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityListRes.java
@@ -1,30 +1,17 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
-import devkor.com.teamcback.domain.building.entity.Building;
-import devkor.com.teamcback.domain.facility.entity.FacilityType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.Getter;
-import lombok.Setter;
 
 @Schema(description = "편의시설 조회 결과")
 @Getter
 public class SearchFacilityListRes {
-    @Schema(description = "편의시설이 위치한 건물 ID", example = "1")
-    private Long buildingId;
-    @Schema(description = "편의시설이 위치한 건물 이름", example = "애기능생활관")
-    private String buildingName;
-    @Schema(description = "편의시설 종류", example = "TRASH_CAN")
-    private FacilityType type;
-    @Schema(description = "각 층별 편의시설 조회 결과")
-    @Setter
-    private Map<Double, List<SearchFacilityRes>> facilities = new HashMap<>();
+    @Schema(description = "편의시설 조회 결과")
+    private List<SearchFacilityRes> facilities = new ArrayList<>();
 
-    public SearchFacilityListRes(Building building, FacilityType type) {
-        this.buildingId = building.getId();
-        this.buildingName = building.getName();
-        this.type = type;
+    public SearchFacilityListRes(List<SearchFacilityRes> facilities) {
+        this.facilities = facilities;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityRes.java
@@ -31,6 +31,8 @@ public class SearchFacilityRes {
     private Double latitude;
     @Schema(description = "편의시설 설명", example = "남자화장실, 여자화장실")
     private String detail;
+    @Schema(description = "편의시설 건물 id", example = "1")
+    private Long buildingId;
     @Schema(description = "편의시설 층", example = "1")
     private int floor;
 
@@ -46,6 +48,7 @@ public class SearchFacilityRes {
         this.longitude = facility.getNode().getLongitude();
         this.latitude = facility.getNode().getLatitude();
         this.detail = facility.getDetail();
+        this.buildingId = facility.getBuilding().getId();
         this.floor = facility.getFloor().intValue();
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -200,7 +200,7 @@ public class SearchService {
      */
     @Transactional(readOnly = true)
     public SearchFacilityListRes searchFacilitiesWithType(FacilityType facilityType) {
-        // TODO: type이 카페/식당/편의점이 아닌 경우에 예외를 발생할 것인지?
+        // TODO: 위경도 값이 null인 facility 예외 처리
         List<SearchFacilityRes> facilityList = facilityRepository.findAllByType(facilityType).stream().map(SearchFacilityRes::new).toList();
 
         return new SearchFacilityListRes(facilityList);


### PR DESCRIPTION
## 개요
특정 편의시설 리스트 조회를 위한 API 추가

## 작업사항
- 기존의 특정 편의시설이 존재하는 건물 조회("/api/search/facilities")를 모든 건물 조회 API("/api/search/buildings")와 통일
  -> 파라미터가 존재하지 않으면(/api/search/buildings) 모든 건물 조회 (야외 제외)
  -> 파라미터가 존재하는 경우(/api/search/buildings?type=CAFE) 해당 편의시설을 가진 건물 조회 (야외 포함)
- 특정 편의시설 리스트 조회를 위한 API 추가 (/api/search/facilities?type=CAFE)
  - 편의시설 타입을 카페, 식당, 편의점으로 제한하지는 않았으나 카페, 식당, 편의점에 해당하는 편의시설만 DB에 위경도 값을 넣음

## 관련 이슈
- 
