### PR TITLE
운영시간 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.building.entity;
 
 import devkor.com.teamcback.domain.common.BaseEntity;
+import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.routes.entity.Node;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,7 +35,11 @@ public class Building extends BaseEntity {
     @Column(nullable = false)
     private String address;
 
-    private String operatingTime;
+    private String operatingTime; // 오늘의 운영 시간
+
+    private String weekdayOperatingTime;
+    private String saturdayOperatingTime;
+    private String sundayOperatingTime;
 
     private boolean isOperating = true;
 
@@ -52,13 +57,15 @@ public class Building extends BaseEntity {
     private Node node;
 
     public void setOperating(boolean operating) {
-        isOperating = operating;
+        this.isOperating = operating;
     }
 
-    public void setOperatingTime(String operatingTime) {
-        String remainingString = "";
-        if(this.operatingTime.length() > 11) remainingString = this.operatingTime.substring(11);
-        this.operatingTime = operatingTime + remainingString;
+    public void updateOperatingTime(DayOfWeek dayOfWeek) {
+        switch(dayOfWeek) {
+            case SUNDAY -> this.operatingTime = sundayOperatingTime;
+            case SATURDAY -> this.operatingTime = saturdayOperatingTime;
+            case WEEKDAY -> this.operatingTime = weekdayOperatingTime;
+        }
     }
 
     @Override

--- a/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/entity/Building.java
@@ -66,6 +66,8 @@ public class Building extends BaseEntity {
             case SATURDAY -> this.operatingTime = saturdayOperatingTime;
             case WEEKDAY -> this.operatingTime = weekdayOperatingTime;
         }
+
+
     }
 
     @Override

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingCondition.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingCondition.java
@@ -25,9 +25,9 @@ public class OperatingCondition extends BaseEntity {
 
     private Boolean isVacation; // 방학, 학기 중
 
-    @ManyToOne
-    @JoinColumn(name = "building_id")
-    private Building building;
+//    @ManyToOne
+//    @JoinColumn(name = "building_id")
+//    private Building building;
 
     @ManyToOne
     @JoinColumn(name = "place_id")

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/repositoy/OperatingConditionRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/repositoy/OperatingConditionRepository.java
@@ -2,6 +2,7 @@ package devkor.com.teamcback.domain.operatingtime.repositoy;
 
 import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.operatingtime.entity.OperatingCondition;
+import devkor.com.teamcback.domain.place.entity.Place;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,10 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface OperatingConditionRepository extends JpaRepository<OperatingCondition, Long> {
     @Query("SELECT e FROM OperatingCondition e WHERE (e.dayOfWeek = :dayOfWeek OR e.dayOfWeek IS NULL) " +
-    "AND (e.isHoliday = :isHoliday OR e.isHoliday IS NULL)" + "AND (e.isVacation = :isVacation OR e.isVacation IS NULL)")
-    List<OperatingCondition> findAllByDayOfWeekAndIsHolidayAndIsVacationOrNot(@Param("dayOfWeek") DayOfWeek dayOfWeek, @Param("isHoliday") boolean isHoliday, @Param("isVacation") boolean isVacation);
+        "AND (e.isHoliday = :isHoliday OR e.isHoliday IS NULL)" + "AND (e.isVacation = :isVacation OR e.isVacation IS NULL)")
+    List<OperatingCondition> findByDayOfWeekAndIsHolidayAndIsVacationOrNot(@Param("dayOfWeek") DayOfWeek dayOfWeek, @Param("isHoliday") boolean isHoliday, @Param("isVacation") boolean isVacation);
+
+    @Query("SELECT e FROM OperatingCondition e WHERE (e.dayOfWeek = :dayOfWeek OR e.dayOfWeek IS NULL) " +
+    "AND (e.isHoliday = :isHoliday OR e.isHoliday IS NULL)" + "AND (e.isVacation = :isVacation OR e.isVacation IS NULL)" + "AND (e.place = :place)")
+    OperatingCondition findByDayOfWeekAndIsHolidayAndIsVacationAndPlace(@Param("dayOfWeek") DayOfWeek dayOfWeek, @Param("isHoliday") boolean isHoliday, @Param("isVacation") boolean isVacation, @Param("place") Place place);
 }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -5,6 +5,7 @@ import devkor.com.teamcback.domain.operatingtime.service.HolidayService;
 import devkor.com.teamcback.domain.operatingtime.service.OperatingService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,21 +36,22 @@ public class OperatingScheduler {
     private static Boolean isVacation = null;
     private static Boolean isEvenWeek = null;
 
-//    @Scheduled(cron = "0 * * * * *") // 테스트용 1분마다
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
     @EventListener(ApplicationReadyEvent.class)
     public void updateOperatingTime() {
         log.info("운영 시간 업데이트");
+
         LocalDate now = LocalDate.now();
 
         dayOfWeek = findDayOfWeek(now);
         log.info("dayOfWeek: {}", dayOfWeek.toString());
-        isHoliday = isHoliday(now);
-        log.info("isHoliday: {}", isHoliday);
-        isVacation = isVacation(now);
-        log.info("isVacation: {}", isVacation);
 
-        isEvenWeek = false;
+        // 나중에 사용할 수 있어서 남겨둠
+        isHoliday = isHoliday(now); // 공휴일 여부
+        log.info("isHoliday: {}", isHoliday);
+        isVacation = isVacation(now); // 방학 여부
+        log.info("isVacation: {}", isVacation);
+        isEvenWeek = false; // 토요일 짝수 주 여부
         if(dayOfWeek == DayOfWeek.SATURDAY) { // 토요일이면 몇째주 토요일인지 계산
             isEvenWeek = isEvenWeek(now);
             log.info("isEvenWeek: {}", isEvenWeek);
@@ -58,13 +60,13 @@ public class OperatingScheduler {
         operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
-//    @Scheduled(cron = "*/30 * * * * *") // 테스트용 30초마다
+//    @Scheduled(cron = "30 8 * * * *") // 테스트용
     @Scheduled(cron = "0 0,30 * * * *") // 매일 30분마다
     public void updateIsOperating() {
         log.info("운영 여부 업데이트");
-        LocalDateTime nowTime = LocalDateTime.now();
+        LocalTime nowTime = LocalTime.now();
 
-        operatingService.updateIsOperating(nowTime);
+        operatingService.updateIsOperating(nowTime, dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
     private DayOfWeek findDayOfWeek(LocalDate date) {

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -45,8 +45,6 @@ public class OperatingScheduler {
 
         dayOfWeek = findDayOfWeek(now);
         log.info("dayOfWeek: {}", dayOfWeek.toString());
-
-        // 나중에 사용할 수 있어서 남겨둠
         isHoliday = isHoliday(now); // 공휴일 여부
         log.info("isHoliday: {}", isHoliday);
         isVacation = isVacation(now); // 방학 여부

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -69,6 +69,14 @@ public class OperatingScheduler {
         operatingService.updateIsOperating(nowTime, dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
+    // 장소 운영 시간 저장 - 건물의 운영 시간에 변동이 있을 경우 1회 작동
+//    @Scheduled(cron = "0 15 * * * *") // 테스트용
+    public void updatePlaceOperatingTime() {
+        log.info("장소 운영 시간 업데이트");
+
+        operatingService.updatePlaceOperatingTime();
+    }
+
     private DayOfWeek findDayOfWeek(LocalDate date) {
         switch (date.getDayOfWeek()) {
             case SATURDAY -> {

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -120,7 +120,8 @@ public class OperatingService {
             OperatingCondition operatingCondition = findOperatingConditionOfPlace(dayOfWeek, isHoliday, isVacation, isEvenWeek, place);
             place = em.merge(place);
             log.info("is managed: {}", em.contains(place));
-            place.setOperating(checkIsOperating(operatingCondition, now));
+//            place.setOperating(checkIsOperating(operatingCondition, now)); // 중간에 쉬는 시간에 운영 여부를 false로 표시
+            place.setOperating(checkIsOperating(place.getOperatingTime(), now)); // 중간에 쉬는 시간에도 운영 여부를 true로 표시
         }
     }
 
@@ -177,25 +178,25 @@ public class OperatingService {
         return operatingConditionList;
     }
 
-    // 운영 시간 확인
-    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
-        int hour = now.getHour();
-        int minute = now.getMinute();
-        log.info("hour: {}", hour);
-        log.info("minute: {}", minute);
-
-        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
-
-        // 운영 여부 판단
-        for(OperatingTime operatingTime : operatingTimeList) {
-            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
-                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
-                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
-                return true;
-            }
-        }
-        return false;
-    }
+//    // 운영 조건으로 운영 여부 확인
+//    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
+//        int hour = now.getHour();
+//        int minute = now.getMinute();
+//        log.info("hour: {}", hour);
+//        log.info("minute: {}", minute);
+//
+//        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
+//
+//        // 운영 여부 판단
+//        for(OperatingTime operatingTime : operatingTimeList) {
+//            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
+//                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
+//                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
+//                return true;
+//            }
+//        }
+//        return false;
+//    }
 
     private String formatTimeRange(LocalTime start, LocalTime end) {
         // 포맷을 "HH:mm" 형식으로 지정

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -35,7 +35,7 @@ public class OperatingService {
     private final BuildingRepository buildingRepository;
     private final PlaceRepository placeRepository;
     private final EntityManager em;
-    private static List<Place> placesWithCondition; // 운영 조건을 가진 장소
+    private static List<Place> placesWithCondition = new ArrayList<>(); // 운영 조건을 가진 장소
     public static final String OPERATING_TIME_PATTERN = "^([0-1]?\\d|2[0-3]):[0-5]\\d-([0-1]?\\d|2[0-3]):[0-5]\\d$";
     // 상시 개방 건물
     private static final List<Long> alwaysOpenBuildings = List.of(0L, 23L, 27L, 60L);
@@ -82,7 +82,7 @@ public class OperatingService {
         }
 
         // 장소만의 운영 시간을 가진 장소들
-        placesWithCondition = operatingConditionRepository.findAll().stream().map(OperatingCondition::getPlace).distinct().toList();;
+        placesWithCondition = operatingConditionRepository.findAll().stream().map(OperatingCondition::getPlace).distinct().toList();
     }
 
     @Transactional
@@ -120,8 +120,8 @@ public class OperatingService {
             OperatingCondition operatingCondition = findOperatingConditionOfPlace(dayOfWeek, isHoliday, isVacation, isEvenWeek, place);
             place = em.merge(place);
             log.info("is managed: {}", em.contains(place));
-//            place.setOperating(checkIsOperating(operatingCondition, now)); // 중간에 쉬는 시간에 운영 여부를 false로 표시
-            place.setOperating(checkIsOperating(place.getOperatingTime(), now)); // 중간에 쉬는 시간에도 운영 여부를 true로 표시
+            place.setOperating(checkIsOperating(operatingCondition, now)); // 중간에 쉬는 시간에 운영 여부를 false로 표시
+//            place.setOperating(checkIsOperating(place.getOperatingTime(), now)); // 중간에 쉬는 시간에도 운영 여부를 true로 표시
         }
     }
 
@@ -178,25 +178,25 @@ public class OperatingService {
         return operatingConditionList;
     }
 
-//    // 운영 조건으로 운영 여부 확인
-//    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
-//        int hour = now.getHour();
-//        int minute = now.getMinute();
-//        log.info("hour: {}", hour);
-//        log.info("minute: {}", minute);
-//
-//        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
-//
-//        // 운영 여부 판단
-//        for(OperatingTime operatingTime : operatingTimeList) {
-//            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
-//                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
-//                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
-//                return true;
-//            }
-//        }
-//        return false;
-//    }
+    // 운영 조건으로 운영 여부 확인
+    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
+        int hour = now.getHour();
+        int minute = now.getMinute();
+        log.info("hour: {}", hour);
+        log.info("minute: {}", minute);
+
+        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
+
+        // 운영 여부 판단
+        for(OperatingTime operatingTime : operatingTimeList) {
+            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
+                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
+                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private String formatTimeRange(LocalTime start, LocalTime end) {
         // 포맷을 "HH:mm" 형식으로 지정

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -168,4 +168,17 @@ public class OperatingService {
         }
         return false;
     }
+
+    // 장소 운영 시간 저장(건물 운영 시간 변동이 있을 경우에만)
+    @Transactional
+    public void updatePlaceOperatingTime() {
+        List<Place> places = placeRepository.findAll();
+
+        for(Place place : places) {
+            if(placesWithCondition.contains(place)) continue;
+            place.setSundayOperatingTime(place.getBuilding().getSundayOperatingTime());
+            place.setSaturdayOperatingTime(place.getBuilding().getSaturdayOperatingTime());
+            place.setWeekdayOperatingTime(place.getBuilding().getWeekdayOperatingTime());
+        }
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -35,6 +35,7 @@ public class OperatingService {
     private final PlaceRepository placeRepository;
     private final EntityManager em;
     private static List<Place> placesWithCondition; // 운영 조건을 가진 장소
+    public static final String OPERATING_TIME_PATTERN = "^([0-1]?\\d|2[0-3]):[0-5]\\d-([0-1]?\\d|2[0-3]):[0-5]\\d$";
     private static final List<Long> alwaysOpenBuildings = List.of(0L, 23L, 27L, 60L);
     private static final List<String> nonAlwaysOpenState = List.of("출입 신청 필요", "경비해제 시 오픈", "자체 관리");
 

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -55,7 +55,6 @@ public class OperatingService {
         }
 
         // 오늘에 해당하는 운영 조건을 가진 장소들
-        List<Place> placeList = new ArrayList<>();
         List<OperatingCondition> operatingConditions = findOperatingConditionList(dayOfWeek, isHoliday, isVacation, isEvenWeek);
 
         for(OperatingCondition operatingCondition : operatingConditions) {
@@ -79,11 +78,11 @@ public class OperatingService {
             String newOperatingTime = formatTimeRange(startTime, endTime);
 
             operatingCondition.getPlace().setOperatingTime(newOperatingTime);
-            placeList.add(operatingCondition.getPlace());
 
         }
 
-        placesWithCondition = placeList;
+        // 장소만의 운영 시간을 가진 장소들
+        placesWithCondition = operatingConditionRepository.findAll().stream().map(OperatingCondition::getPlace).distinct().toList();;
     }
 
     @Transactional
@@ -214,11 +213,9 @@ public class OperatingService {
     @Transactional
     public void updatePlaceOperatingTime() {
         List<Place> places = placeRepository.findAll();
-        List<Place> otherPlaces = operatingConditionRepository.findAll().stream().map(OperatingCondition::getPlace).distinct().toList();
-        log.info("otherPlaces: {}", otherPlaces.size());
 
         for(Place place : places) {
-            if(!otherPlaces.contains(place)) {
+            if(!placesWithCondition.contains(place)) {
                 place.setSundayOperatingTime(place.getBuilding().getSundayOperatingTime());
                 place.setSaturdayOperatingTime(place.getBuilding().getSaturdayOperatingTime());
                 place.setWeekdayOperatingTime(place.getBuilding().getWeekdayOperatingTime());

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -220,6 +220,7 @@ public class OperatingService {
                 place.setSundayOperatingTime(place.getBuilding().getSundayOperatingTime());
                 place.setSaturdayOperatingTime(place.getBuilding().getSaturdayOperatingTime());
                 place.setWeekdayOperatingTime(place.getBuilding().getWeekdayOperatingTime());
+                place.setOperating(place.getBuilding().isOperating());
             }
         }
     }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -32,124 +32,81 @@ public class OperatingService {
     private final OperatingTimeRepository operatingTimeRepository;
     private final NodeRepository nodeRepository;
     private final BuildingRepository buildingRepository;
-//    private final ClassroomRepository classroomRepository;
     private final PlaceRepository placeRepository;
-    private final EntityManager entityManager;
-
-    private static List<OperatingCondition> operatingConditionList = new ArrayList<>();
-//    private static List<Classroom> notOperatingClassrooms = new ArrayList<>();
-    private static List<Place> notOperatingFacilities = new ArrayList<>();
+    private final EntityManager em;
+    private static List<Place> placesWithCondition; // 운영 조건을 가진 장소
+    private static final List<Long> alwaysOpenBuildings = List.of(0L, 23L, 27L, 60L);
+    private static final List<String> nonAlwaysOpenState = List.of("출입 신청 필요", "경비해제 시 오픈", "자체 관리");
 
     @Transactional
-    public void updateOperatingTime(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean evenWeek) {
-        List<Building> buildingList = new ArrayList<>();
-        List<Place> placeList = new ArrayList<>();
-
-        operatingConditionList  = findOperatingCondition(dayOfWeek, isHoliday, isVacation, evenWeek);
-
-        for(OperatingCondition operatingCondition : operatingConditionList) {
-            List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
-
-            LocalTime endTime = LocalTime.of(0, 0);
-            LocalTime startTime = LocalTime.of(23, 59);
-
-            for(OperatingTime operatingTime : operatingTimeList) {
-                LocalTime end = LocalTime.of(operatingTime.getEndHour(), operatingTime.getEndMinute());
-                LocalTime start = LocalTime.of(operatingTime.getStartHour(), operatingTime.getStartMinute());
-                if(endTime.isBefore(end)) endTime = end;
-                if(startTime.isAfter(start)) startTime = start;
-            }
-
-            String newOperatingTime = formatTimeRange(startTime, endTime);
-
-            if(operatingCondition.getBuilding() != null) {
-                operatingCondition.getBuilding().setOperatingTime(newOperatingTime);
-                buildingList.add(operatingCondition.getBuilding());
-            }
-            else if(operatingCondition.getPlace() != null) {
-                operatingCondition.getPlace().setOperatingTime(newOperatingTime);
-                placeList.add(operatingCondition.getPlace());
-            }
+    public void updateOperatingTime(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek) {
+        // 건물 운영 시간
+        List<Building> buildings = buildingRepository.findAll();
+        for(Building building : buildings) {
+            building.updateOperatingTime(dayOfWeek);
         }
 
-        // 운영조건에 포함되지 못한 건물, 강의실, 편의시설
-        List<Building> notOperatingBuildings = buildingRepository.findAllByIdNotIn(buildingList.stream().map(Building::getId).toList());
-        for(Building building : notOperatingBuildings) {
-            if(building.getId() != 0) building.setOperating(false);
+        // 장소 운영 시간
+        List<Place> places = placeRepository.findAll();
+        for(Place place : places) {
+            place.updateOperatingTime(dayOfWeek);
         }
 
-        if(placeList.isEmpty()) notOperatingFacilities = placeRepository.findAll();
-        else notOperatingFacilities = placeRepository.findAllByIdNotIn(placeList.stream().map(Place::getId).toList());
-
+        // 오늘에 해당하는 운영 조건을 가진 장소들
+        List<OperatingCondition> operatingConditions = findOperatingConditionList(dayOfWeek, isHoliday, isVacation, isEvenWeek);
+        placesWithCondition = operatingConditions.stream().map(OperatingCondition::getPlace).distinct().toList();
     }
 
     @Transactional
-    public void updateIsOperating(LocalDateTime now) {
-        for(OperatingCondition operCondition : operatingConditionList) {
-            boolean isOperating = checkOperatingTime(operCondition, now);
-            log.info("isOperating: {}", isOperating);
-
-            if(operCondition.getBuilding() != null) {
-                Building building = operCondition.getBuilding();
-                building = entityManager.merge(building);
-                log.info("building: {}", building.getName());
-                if(building.isOperating() != isOperating) {
-                    building.setOperating(isOperating);
-                    changeNodeIsOperating(isOperating, building);
+    public void updateIsOperating(LocalTime now, DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek) {
+        List<Building> buildings = buildingRepository.findAll();
+        for(Building building : buildings) {
+            // 상시 개방이 아닌 건물만 확인
+            if(!alwaysOpenBuildings.contains(building.getId())) {
+                // 운영 시간이 아닌 다른 문자열 혹은 null인 건물은 false
+                if(building.getOperatingTime() == null || nonAlwaysOpenState.contains(building.getOperatingTime())) {
+                    building.setOperating(false);
                 }
-            }
-            else if(operCondition.getPlace() != null) {
-                Place place = operCondition.getPlace();
-                place = entityManager.merge(place);
-                log.info("facility: {}", place.getName());
-                if(place.isOperating() != isOperating) {
-                    place.setOperating(isOperating);
+                // 운영 중인지 확인
+                else {
+                    boolean isOperating = checkIsOperating(building.getOperatingTime(), now);
+                    // 운영 여부에 변화가 있는 경우
+                    if(building.isOperating() != isOperating) {
+                        log.info("building: {}, isOperating: {}", building.getName(), isOperating);
+                        // 출입구 노드 운영 여부 변경
+                        changeNodeIsOperating(isOperating, building);
+                        // 건물 운영 여부 변경
+                        building.setOperating(isOperating);
+                        // 건물에 속하면서 장소 만의 운영 시간이 없는 경우 운영 여부 동기화
+                        List<Place> places = placeRepository.findAllByBuilding(building);
+                        for(Place place : places) {
+                            if(!placesWithCondition.contains(place)) place.setOperating(isOperating);
+                        }
+                    }
                 }
             }
         }
 
-        // 운영 조건에 포함되지 않은 강의실, 편의시설
-        for(Place place : notOperatingFacilities) {
-            place = entityManager.merge(place);
-            place.setOperating(place.getBuilding().isOperating()); // 건물 운영여부를 따라감
+        // 운영 조건을 가진 장소 운영 시간 변경
+        for(Place place : placesWithCondition) {
+            OperatingCondition operatingCondition = findOperatingConditionOfPlace(dayOfWeek, isHoliday, isVacation, isEvenWeek, place);
+            place = em.merge(place);
+            log.info("is managed: {}", em.contains(place));
+            place.setOperating(checkIsOperating(operatingCondition, now));
         }
     }
 
-    private List<OperatingCondition> findOperatingCondition(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean evenWeek) {
-        List<OperatingCondition> operatingConditionList  = operatingConditionRepository.findAllByDayOfWeekAndIsHolidayAndIsVacationOrNot(dayOfWeek, isHoliday, isVacation);
+    // 문자열 운영 시간이 현재 시간을 포함하는지 확인하여 운영 여부 판단
+    private boolean checkIsOperating(String operatingTime, LocalTime now) {
+        int startHour = Integer.parseInt(operatingTime.substring(0,2));
+        int startMinute = Integer.parseInt(operatingTime.substring(3,5));
+        int endHour = Integer.parseInt(operatingTime.substring(6,8));
+        int endMinute = Integer.parseInt(operatingTime.substring(9,11));
 
-        if(dayOfWeek == DayOfWeek.SATURDAY) { // 토요일인 경우
-            if(evenWeek) {
-                operatingConditionList.stream().filter(operatingCondition ->
-                    operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek() == true);
-            }
-            else {
-                operatingConditionList.stream().filter(operatingCondition ->
-                    operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek() == false);
-            }
-        }
+        LocalTime startTime = LocalTime.of(startHour, startMinute);
+        LocalTime endTime = LocalTime.of(endHour, endMinute);
 
-        return operatingConditionList;
-    }
-
-    // 운영 시간 확인
-    private boolean checkOperatingTime(OperatingCondition operatingCondition, LocalDateTime now) {
-        int hour = now.getHour();
-        int minute = now.getMinute();
-        log.info("hour: {}", hour);
-        log.info("minute: {}", minute);
-
-        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
-
-        // 운영 여부 판단
-        for(OperatingTime operatingTime : operatingTimeList) {
-            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
-                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
-                (hour == operatingTime.getEndHour() && minute <= operatingTime.getEndMinute())) {
-                return true;
-            }
-        }
-        return false;
+        return !now.isBefore(startTime) && now.isBefore(endTime);
     }
 
     // 건물 운영 여부에 따라 출입문 routing 변경
@@ -161,15 +118,54 @@ public class OperatingService {
         }
     }
 
-    private String formatTimeRange(LocalTime start, LocalTime end) {
-        // 포맷을 "HH:mm" 형식으로 지정
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+    // 오늘에 맞는 운영 조건 찾기
+    private OperatingCondition findOperatingConditionOfPlace(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek, Place place) {
+        OperatingCondition operatingCondition  = operatingConditionRepository.findByDayOfWeekAndIsHolidayAndIsVacationAndPlace(dayOfWeek, isHoliday, isVacation, place);
 
-        // 각각의 LocalTime을 포맷된 문자열로 변환
-        String startFormatted = start.format(formatter);
-        String endFormatted = end.format(formatter);
+        if(operatingCondition == null) return null;
 
-        // 두 시간 문자열을 "HH:mm-HH:mm" 형식으로 연결
-        return startFormatted + "-" + endFormatted;
+        if(dayOfWeek == DayOfWeek.SATURDAY) { // 토요일인 경우
+            if(operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek() == isEvenWeek) return operatingCondition;
+            else return null;
+        }
+
+        return operatingCondition;
+    }
+
+    private List<OperatingCondition> findOperatingConditionList(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek) {
+        List<OperatingCondition> operatingConditionList  = operatingConditionRepository.findByDayOfWeekAndIsHolidayAndIsVacationOrNot(dayOfWeek, isHoliday, isVacation);
+
+        if(dayOfWeek == DayOfWeek.SATURDAY) { // 토요일인 경우
+            if(isEvenWeek) {
+                operatingConditionList.stream().filter(operatingCondition ->
+                    operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek());
+            }
+            else {
+                operatingConditionList.stream().filter(operatingCondition ->
+                    operatingCondition.getIsEvenWeek() == null || !operatingCondition.getIsEvenWeek());
+            }
+        }
+
+        return operatingConditionList;
+    }
+
+    // 운영 시간 확인
+    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
+        int hour = now.getHour();
+        int minute = now.getMinute();
+        log.info("hour: {}", hour);
+        log.info("minute: {}", minute);
+
+        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
+
+        // 운영 여부 판단
+        for(OperatingTime operatingTime : operatingTimeList) {
+            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
+                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
+                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -19,6 +19,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,8 +37,8 @@ public class OperatingService {
     private final EntityManager em;
     private static List<Place> placesWithCondition; // 운영 조건을 가진 장소
     public static final String OPERATING_TIME_PATTERN = "^([0-1]?\\d|2[0-3]):[0-5]\\d-([0-1]?\\d|2[0-3]):[0-5]\\d$";
+    // 상시 개방 건물
     private static final List<Long> alwaysOpenBuildings = List.of(0L, 23L, 27L, 60L);
-    private static final List<String> nonAlwaysOpenState = List.of("출입 신청 필요", "경비해제 시 오픈", "자체 관리");
 
     @Transactional
     public void updateOperatingTime(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek) {
@@ -54,8 +55,35 @@ public class OperatingService {
         }
 
         // 오늘에 해당하는 운영 조건을 가진 장소들
+        List<Place> placeList = new ArrayList<>();
         List<OperatingCondition> operatingConditions = findOperatingConditionList(dayOfWeek, isHoliday, isVacation, isEvenWeek);
-        placesWithCondition = operatingConditions.stream().map(OperatingCondition::getPlace).distinct().toList();
+
+        for(OperatingCondition operatingCondition : operatingConditions) {
+            List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(
+                operatingCondition);
+
+            LocalTime endTime = LocalTime.of(0, 0);
+            LocalTime startTime = LocalTime.of(23, 59);
+
+            for (OperatingTime operatingTime : operatingTimeList) {
+                LocalTime end = LocalTime.of(operatingTime.getEndHour(),
+                    operatingTime.getEndMinute());
+                LocalTime start = LocalTime.of(operatingTime.getStartHour(),
+                    operatingTime.getStartMinute());
+                if (endTime.isBefore(end))
+                    endTime = end;
+                if (startTime.isAfter(start))
+                    startTime = start;
+            }
+
+            String newOperatingTime = formatTimeRange(startTime, endTime);
+
+            operatingCondition.getPlace().setOperatingTime(newOperatingTime);
+            placeList.add(operatingCondition.getPlace());
+
+        }
+
+        placesWithCondition = placeList;
     }
 
     @Transactional
@@ -65,7 +93,7 @@ public class OperatingService {
             // 상시 개방이 아닌 건물만 확인
             if(!alwaysOpenBuildings.contains(building.getId())) {
                 // 운영 시간이 아닌 다른 문자열 혹은 null인 건물은 false
-                if(building.getOperatingTime() == null || nonAlwaysOpenState.contains(building.getOperatingTime())) {
+                if(building.getOperatingTime() == null || !Pattern.matches(OPERATING_TIME_PATTERN, building.getOperatingTime())) {
                     building.setOperating(false);
                 }
                 // 운영 중인지 확인
@@ -168,6 +196,18 @@ public class OperatingService {
             }
         }
         return false;
+    }
+
+    private String formatTimeRange(LocalTime start, LocalTime end) {
+        // 포맷을 "HH:mm" 형식으로 지정
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        // 각각의 LocalTime을 포맷된 문자열로 변환
+        String startFormatted = start.format(formatter);
+        String endFormatted = end.format(formatter);
+
+        // 두 시간 문자열을 "HH:mm-HH:mm" 형식으로 연결
+        return startFormatted + "-" + endFormatted;
     }
 
     // 장소 운영 시간 저장(건물 운영 시간 변동이 있을 경우에만)

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -214,12 +214,15 @@ public class OperatingService {
     @Transactional
     public void updatePlaceOperatingTime() {
         List<Place> places = placeRepository.findAll();
+        List<Place> otherPlaces = operatingConditionRepository.findAll().stream().map(OperatingCondition::getPlace).distinct().toList();
+        log.info("otherPlaces: {}", otherPlaces.size());
 
         for(Place place : places) {
-            if(placesWithCondition.contains(place)) continue;
-            place.setSundayOperatingTime(place.getBuilding().getSundayOperatingTime());
-            place.setSaturdayOperatingTime(place.getBuilding().getSaturdayOperatingTime());
-            place.setWeekdayOperatingTime(place.getBuilding().getWeekdayOperatingTime());
+            if(!otherPlaces.contains(place)) {
+                place.setSundayOperatingTime(place.getBuilding().getSundayOperatingTime());
+                place.setSaturdayOperatingTime(place.getBuilding().getSaturdayOperatingTime());
+                place.setWeekdayOperatingTime(place.getBuilding().getWeekdayOperatingTime());
+            }
         }
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
@@ -9,6 +9,7 @@ import devkor.com.teamcback.domain.routes.entity.Node;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -42,8 +43,11 @@ public class Place extends BaseEntity {
 
     private String operatingTime;
 
+    @Setter
     private String weekdayOperatingTime;
+    @Setter
     private String saturdayOperatingTime;
+    @Setter
     private String sundayOperatingTime;
 
     private boolean isOperating;

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
@@ -1,5 +1,6 @@
 package devkor.com.teamcback.domain.place.entity;
 
+import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.place.dto.request.CreatePlaceReq;
 import devkor.com.teamcback.domain.place.dto.request.ModifyPlaceReq;
 import devkor.com.teamcback.domain.building.entity.Building;
@@ -40,6 +41,10 @@ public class Place extends BaseEntity {
     private String imageUrl;
 
     private String operatingTime;
+
+    private String weekdayOperatingTime;
+    private String saturdayOperatingTime;
+    private String sundayOperatingTime;
 
     private boolean isOperating;
 
@@ -90,12 +95,18 @@ public class Place extends BaseEntity {
     }
 
     public void setOperating(boolean operating) {
-        isOperating = operating;
+        this.isOperating = operating;
     }
 
-    public void setOperatingTime(String operatingTime) {
-        String remainingString = "";
-        if(this.operatingTime.length() > 11) remainingString = this.operatingTime.substring(11);
-        this.operatingTime = operatingTime + remainingString;
+    public void updateOperatingTime(DayOfWeek dayOfWeek) {
+        switch(dayOfWeek) {
+            case SUNDAY -> this.operatingTime = sundayOperatingTime;
+            case SATURDAY -> this.operatingTime = saturdayOperatingTime;
+            case WEEKDAY -> this.operatingTime = weekdayOperatingTime;
+        }
+
+        if(this.operatingTime == null) {
+            this.operatingTime = this.building.getOperatingTime();
+        }
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
@@ -102,6 +102,10 @@ public class Place extends BaseEntity {
         this.isOperating = operating;
     }
 
+    public void setOperatingTime(String operatingTime) {
+        this.operatingTime = operatingTime;
+    }
+
     public void updateOperatingTime(DayOfWeek dayOfWeek) {
         switch(dayOfWeek) {
             case SUNDAY -> this.operatingTime = sundayOperatingTime;

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceType.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceType.java
@@ -33,7 +33,8 @@ public enum PlaceType {
     SHUTTLE_BUS("셔틀버스정거장"),
     BOOK_RETURN_MACHINE("도서반납기"),
     TUMBLER_WASHER("텀블러세척기"),
-    ONESTOP_AUTO_MACHINE("원스탑무인발급기");
+    ONESTOP_AUTO_MACHINE("원스탑무인발급기"),
+    KOYEON("고연전주점");
 
     private final String name;
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -1,6 +1,5 @@
 package devkor.com.teamcback.domain.search.contoller;
 
-import devkor.com.teamcback.domain.common.LocationType;
 import devkor.com.teamcback.domain.place.entity.PlaceType;
 import devkor.com.teamcback.domain.search.dto.request.SaveSearchLogReq;
 import devkor.com.teamcback.domain.search.dto.response.*;

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingDetailRes.java
@@ -1,8 +1,11 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
+import static devkor.com.teamcback.domain.operatingtime.service.OperatingService.OPERATING_TIME_PATTERN;
+
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.place.entity.PlaceType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.regex.Pattern;
 import lombok.Getter;
 
 import java.util.List;
@@ -18,8 +21,12 @@ public class SearchBuildingDetailRes {
     private String address;
     @Schema(description = "건물 사진 url", example = "building_url")
     private String imageUrl;
-    @Schema(description = "운영 시간", example = "9:00-22:00")
-    private String operatingTime;
+    @Schema(description = " 평일 운영 시간", example = "9:00-22:00")
+    private String weekdayOperatingTime;
+    @Schema(description = " 토요일 운영 시간", example = "9:00-22:00")
+    private String saturdayOperatingTime;
+    @Schema(description = " 일요일 운영 시간", example = "9:00-22:00")
+    private String sundayOperatingTime;
     @Schema(description = "건물 정보(TMI)", example = "애기능생활관이다.")
     private String details;
     @Schema(description = "북마크 저장 여부", example = "false")
@@ -38,13 +45,18 @@ public class SearchBuildingDetailRes {
         this.name = "고려대학교 서울캠퍼스 " + building.getName();
         this.address = building.getAddress();
         this.imageUrl = building.getImageUrl();
-        this.operatingTime = building.getOperatingTime();
+        this.weekdayOperatingTime = building.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = building.getSaturdayOperatingTime();
+        this.sundayOperatingTime = building.getSundayOperatingTime();
         this.details = building.getDetail();
         this.bookmarked = bookmarked;
         this.existTypes = types;
         this.mainFacilityList = facilities;
         this.isOperating = building.isOperating();
-        if(building.isOperating()) { // 운영 중이면 종료 시간
+        if(building.getOperatingTime() == null || !Pattern.matches(OPERATING_TIME_PATTERN, building.getOperatingTime())) {
+            this.nextBuildingTime = null;
+        }
+        else if(building.isOperating()) { // 운영 중이면 종료 시간
             this.nextBuildingTime = building.getOperatingTime().substring(6, 11);
         }
         else { // 운영 종료인 경우 여는 시간

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchBuildingRes.java
@@ -1,10 +1,13 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
+import static devkor.com.teamcback.domain.operatingtime.service.OperatingService.OPERATING_TIME_PATTERN;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.place.entity.PlaceType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -15,7 +18,9 @@ public class SearchBuildingRes {
     private String imageUrl;
     private String detail;
     private String address;
-    private String operatingTime;
+    private String weekdayOperatingTime;
+    private String saturdayOperatingTime;
+    private String sundayOperatingTime;
     private boolean isOperating;
     private Boolean needStudentCard;
     private Double longitude;
@@ -32,7 +37,9 @@ public class SearchBuildingRes {
         this.imageUrl = building.getImageUrl();
         this.detail = building.getDetail();
         this.address = building.getAddress();
-        this.operatingTime = building.getOperatingTime();
+        this.weekdayOperatingTime = building.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = building.getSaturdayOperatingTime();
+        this.sundayOperatingTime = building.getSundayOperatingTime();
         this.needStudentCard = building.isNeedStudentCard();
         if(building.getId() != 0) {
         this.longitude = building.getNode().getLongitude();
@@ -42,7 +49,10 @@ public class SearchBuildingRes {
         this.underFloor = building.getUnderFloor();
         this.placeTypes = placeTypes;
         this.isOperating = building.isOperating();
-        if(building.isOperating()) { // 운영 중이면 종료 시간
+        if(building.getOperatingTime() == null || !Pattern.matches(OPERATING_TIME_PATTERN, building.getOperatingTime())) {
+            this.nextBuildingTime = null;
+        }
+        else if(building.isOperating()) { // 운영 중이면 종료 시간
             this.nextBuildingTime = building.getOperatingTime().substring(6, 11);
         }
         else { // 운영 종료인 경우 여는 시간

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFacilityRes.java
@@ -1,13 +1,11 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import devkor.com.teamcback.domain.place.entity.Place;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Schema(description = "편의시설 정보")
 @Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SearchFacilityRes {
     @Schema(description = "편의시설 ID", example = "1")
     private Long facilityId;
@@ -15,8 +13,12 @@ public class SearchFacilityRes {
     private String name;
     @Schema(description = "편의시설 이용 가능 여부", example = "true")
     private Boolean availability;
-    @Schema(description = "운영 시간", example = "08:30-17:00")
-    private String operatingTime;
+    @Schema(description = " 평일 운영 시간", example = "9:00-22:00")
+    private String weekdayOperatingTime;
+    @Schema(description = " 토요일 운영 시간", example = "9:00-22:00")
+    private String saturdayOperatingTime;
+    @Schema(description = " 일요일 운영 시간", example = "9:00-22:00")
+    private String sundayOperatingTime;
     @Schema(description = "운영 여부", example = "true")
     private boolean isOperating;
     @Schema(description = "편의시설 image url", example = "url")
@@ -40,7 +42,9 @@ public class SearchFacilityRes {
         this.facilityId = place.getId();
         this.name = place.getName();
         this.availability = place.isAvailability();
-        this.operatingTime = place.getOperatingTime();
+        this.weekdayOperatingTime = place.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = place.getSaturdayOperatingTime();
+        this.sundayOperatingTime = place.getSundayOperatingTime();
         this.isOperating = place.isOperating();
         this.imageUrl = place.getImageUrl();
         this.xCoord = place.getNode().getXCoord();

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceDetailRes.java
@@ -1,9 +1,13 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
+import static devkor.com.teamcback.domain.operatingtime.service.OperatingService.OPERATING_TIME_PATTERN;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import devkor.com.teamcback.domain.common.LocationType;
 import devkor.com.teamcback.domain.place.entity.Place;
 import devkor.com.teamcback.domain.place.entity.PlaceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +26,9 @@ public class SearchPlaceDetailRes {
     private boolean availability;  //사용 가능 여부
     private boolean plugAvailability;
     private String imageUrl;
-    private String operatingTime;
+    private String weekdayOperatingTime;
+    private String saturdayOperatingTime;
+    private String sundayOperatingTime;
     private Double longitude;
     private Double latitude;
     private double xCoord;
@@ -51,11 +57,16 @@ public class SearchPlaceDetailRes {
         this.availability = place.isAvailability();
         this.plugAvailability = place.isPlugAvailability();
         this.imageUrl = place.getImageUrl();
-        this.operatingTime = place.getOperatingTime();
+        this.weekdayOperatingTime = place.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = place.getSaturdayOperatingTime();
+        this.sundayOperatingTime = place.getSundayOperatingTime();
         this.maskIndex = place.getMaskIndex();
         this.bookmarked = bookmarked;
         this.isOperating = place.isOperating();
-        if(place.isOperating()) { // 운영 중이면 종료 시간
+        if(place.getOperatingTime() == null || !Pattern.matches(OPERATING_TIME_PATTERN, place.getOperatingTime())) {
+            this.nextPlaceTime = null;
+        }
+        else if(place.isOperating()) { // 운영 중이면 종료 시간
             this.nextPlaceTime = place.getOperatingTime().substring(6, 11);
         }
         else { // 운영 종료인 경우 여는 시간

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchPlaceRes.java
@@ -1,6 +1,5 @@
 package devkor.com.teamcback.domain.search.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.common.LocationType;
 import devkor.com.teamcback.domain.place.entity.Place;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 @Schema(description = "건물 및 강의실 조회 결과")
 @Getter
 @NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SearchPlaceRes {
     @Schema(description = "건물 또는 강의실 id", example = "1")
     private Long id;
@@ -29,8 +27,12 @@ public class SearchPlaceRes {
     private Double floor;
     @Schema(description = "건물 주소", example = "서울특별시 성북구 안암로 145 고려대학교 애기능생활관")
     private String address;
-    @Schema(description = "건물 운영 시간", example = "00:00~00:00")
-    private String operatingTime;
+    @Schema(description = " 평일 운영 시간", example = "9:00-22:00")
+    private String weekdayOperatingTime;
+    @Schema(description = " 토요일 운영 시간", example = "9:00-22:00")
+    private String saturdayOperatingTime;
+    @Schema(description = " 일요일 운영 시간", example = "9:00-22:00")
+    private String sundayOperatingTime;
     @Schema(description = "건물 운영 여부", example = "true")
     private boolean isOperating;
     @Schema(description = "건물 출입 시 학생증 필요 여부", example = "false")
@@ -56,7 +58,9 @@ public class SearchPlaceRes {
         this.imageUrl = building.getImageUrl();
         this.detail = building.getDetail();
         this.address = building.getAddress();
-        this.operatingTime = building.getOperatingTime();
+        this.weekdayOperatingTime = building.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = building.getSaturdayOperatingTime();
+        this.sundayOperatingTime = building.getSundayOperatingTime();
         this.isOperating = building.isOperating();
         this.needStudentCard = building.isNeedStudentCard();
         this.longitude = building.getNode().getLongitude();
@@ -71,7 +75,9 @@ public class SearchPlaceRes {
         this.name = place.getName();
         this.imageUrl = place.getImageUrl();
         this.detail = place.getDetail();
-        this.operatingTime = place.getOperatingTime();
+        this.weekdayOperatingTime = place.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = place.getSaturdayOperatingTime();
+        this.sundayOperatingTime = place.getSundayOperatingTime();
         this.isOperating = place.isOperating();
         this.floor = place.getFloor();
         this.plugAvailability = place.isPlugAvailability();

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchRoomDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchRoomDetailRes.java
@@ -17,7 +17,9 @@ public class SearchRoomDetailRes {
     private boolean availability;
     private boolean plugAvailability;
     private String imageUrl;
-    private String operatingTime;
+    private String weekdayOperatingTime;
+    private String saturdayOperatingTime;
+    private String sundayOperatingTime;
     private boolean isOperating;
     private Double longitude;
     private Double latitude;
@@ -33,7 +35,9 @@ public class SearchRoomDetailRes {
         this.availability = place.isAvailability();
         this.plugAvailability = place.isPlugAvailability();
         this.imageUrl = place.getImageUrl();
-        this.operatingTime = place.getOperatingTime();
+        this.weekdayOperatingTime = place.getWeekdayOperatingTime();
+        this.saturdayOperatingTime = place.getSaturdayOperatingTime();
+        this.sundayOperatingTime = place.getSundayOperatingTime();
         this.isOperating = place.isOperating();
         this.longitude = place.getNode().getLongitude();
         this.latitude = place.getNode().getLatitude();


### PR DESCRIPTION
## 개요
건물, 장소에 평일/토/일 운영 시간 추가
건물은 평일/토/일 운영 시간으로 운영 여부 판단, 장소는 운영 조건을 이용해서 운영 여부 판단

## 작업사항
- 건물, 장소에 평일/토/일 운영 시간 추가
    - 한 번 저장되면 되도록 변하지 않는다고 가정
    - 변경되는 것은 기존의 operatingTime으로 당일의 운영 시간을 임시적으로 저장하여 운영 여부를 판단하는데 사용
- 추가한 평일/토/일 운영 시간 정보를 반환하도록 dto 수정
- 건물 및 몇몇 장소의 운영 시간 정보 DB에 저장
- 장소의 경우, 매일 해당하는 평일/토/일 운영 시간을 일단 가져온 뒤(없으면 건물 시간을 가져옴) 운영 조건이 있으면 운영 조건에 따른 시간으로 수정하여 운영 여부를 판단
   - 이유: 건물에 비해 상대적으로 운영 여부에 공휴일, 둘째 주 토요일, 방학 여부 등을 판단할 필요가 있음

## 관련 이슈
- 
