### PR TITLE
Fix/operatingtime 쉬는 시간 고려하도록 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -58,9 +58,17 @@ public class OperatingScheduler {
         operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
-//    @Scheduled(cron = "30 8 * * * *") // 테스트용
-    @Scheduled(cron = "0 0,30 * * * *") // 매일 30분마다
-    public void updateIsOperating() {
+//    @Scheduled(cron = "30 50 * * * *") // 테스트용
+    @Scheduled(cron = "0 */10 9-18 * * *") // 10분마다
+    public void updateOperatingDuringPeakHour() {
+        log.info("운영 여부 업데이트");
+        LocalTime nowTime = LocalTime.now();
+
+        operatingService.updateIsOperating(nowTime, dayOfWeek, isHoliday, isVacation, isEvenWeek);
+    }
+
+    @Scheduled(cron = "0 0,30 0-8,19-23 * * *") // 30분마다
+    public void updateOperating() {
         log.info("운영 여부 업데이트");
         LocalTime nowTime = LocalTime.now();
 

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/service/OperatingService.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.operatingtime.service;
 
 import static devkor.com.teamcback.domain.routes.entity.NodeType.ENTRANCE;
+import static devkor.com.teamcback.global.response.ResultCode.OPER_CONDITION_HAS_NO_OPER_TIME;
 
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.building.repository.BuildingRepository;
@@ -13,12 +14,12 @@ import devkor.com.teamcback.domain.operatingtime.entity.OperatingCondition;
 import devkor.com.teamcback.domain.operatingtime.entity.OperatingTime;
 import devkor.com.teamcback.domain.operatingtime.repositoy.OperatingConditionRepository;
 import devkor.com.teamcback.domain.operatingtime.repositoy.OperatingTimeRepository;
-import jakarta.persistence.EntityManager;
-import java.time.LocalDateTime;
+import devkor.com.teamcback.global.exception.GlobalException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,20 +64,17 @@ public class OperatingService {
             LocalTime startTime = LocalTime.of(23, 59);
 
             for (OperatingTime operatingTime : operatingTimeList) {
-                LocalTime end = LocalTime.of(operatingTime.getEndHour(),
-                    operatingTime.getEndMinute());
-                LocalTime start = LocalTime.of(operatingTime.getStartHour(),
-                    operatingTime.getStartMinute());
-                if (endTime.isBefore(end))
-                    endTime = end;
-                if (startTime.isAfter(start))
+                LocalTime end = LocalTime.of(operatingTime.getEndHour(), operatingTime.getEndMinute());
+                LocalTime start = LocalTime.of(operatingTime.getStartHour(), operatingTime.getStartMinute());
+                if (startTime.isAfter(start)) {
                     startTime = start;
+                    endTime = end;
+                }
             }
 
             String newOperatingTime = formatTimeRange(startTime, endTime);
 
             operatingCondition.getPlace().setOperatingTime(newOperatingTime);
-
         }
 
     }
@@ -113,12 +111,58 @@ public class OperatingService {
             }
         }
 
-        // 운영 조건을 가진 장소 운영 시간 변경
+        // 운영 조건을 가진 장소 운영 여부, 운영 시간 변경
         for(Place place : placesWithCondition) {
             OperatingCondition operatingCondition = findOperatingConditionOfPlace(dayOfWeek, isHoliday, isVacation, isEvenWeek, place);
-            place.setOperating(checkIsOperating(operatingCondition, now)); // 중간에 쉬는 시간에 운영 여부를 false로 표시
+            if(operatingCondition == null) continue; // 운영 조건을 가졌지만 오늘은 영업하지 않는 경우는 수정 x
+
+            boolean isOperating = false;
+            String operatingTime = null;
+
+            List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
+
+            // 운영 여부 판단 - 운영 중이면 운영 시간 수정
+            for(OperatingTime op : operatingTimeList) {
+                if(!isOperating && isInOperatingTime(now, op)) { // 운영 시간에 포함되는 경우
+                    isOperating = true;
+                    LocalTime start = LocalTime.of(op.getStartHour(), op.getStartMinute());
+                    LocalTime end = LocalTime.of(op.getEndHour(), op.getEndMinute());
+                    operatingTime = formatTimeRange(start, end); // 포함되는 운영 시간으로 설정
+                }
+            }
+
+            place.setOperating(isOperating); // 중간에 쉬는 시간에 운영 여부를 false로 표시
 //            place.setOperating(checkIsOperating(place.getOperatingTime(), now)); // 중간에 쉬는 시간에도 운영 여부를 true로 표시
+
+            // 운영 중이지 않을 경우
+            if(!isOperating) {
+                OperatingTime op = getNextOperatingTime(operatingTimeList, now);
+                LocalTime start = LocalTime.of(op.getStartHour(), op.getStartMinute());
+                LocalTime end = LocalTime.of(op.getEndHour(), op.getEndMinute());
+                operatingTime = formatTimeRange(start, end); // 다음 운영 시간으로 설정
+            }
+
+            place.setOperatingTime(operatingTime);
         }
+    }
+
+    // next time 찾기
+    private OperatingTime getNextOperatingTime(List<OperatingTime> operatingTimeList, LocalTime now) {
+        // 현재 시간 이후에 시작해서 종료하는 시간을 찾음
+        Optional<OperatingTime> nextOperatingTime = operatingTimeList.stream()
+            .filter(ot -> {
+                LocalTime start = LocalTime.of(ot.getStartHour(), ot.getStartMinute());
+                return start.isAfter(now);
+            })
+            .min(Comparator.comparing(ot -> LocalTime.of(ot.getStartHour(), ot.getStartMinute())));
+
+        // 없으면 가장 처음 시작하는 시간을 선택
+        if (nextOperatingTime.isEmpty()) {
+            nextOperatingTime = operatingTimeList.stream()
+                .min(Comparator.comparing(ot -> LocalTime.of(ot.getStartHour(), ot.getStartMinute())));
+        }
+
+        return nextOperatingTime.orElseThrow(() -> new GlobalException(OPER_CONDITION_HAS_NO_OPER_TIME));
     }
 
     // 문자열 운영 시간이 현재 시간을 포함하는지 확인하여 운영 여부 판단
@@ -143,7 +187,7 @@ public class OperatingService {
         }
     }
 
-    // 오늘에 맞는 운영 조건 찾기
+    // 오늘 해당 장소에 맞는 운영 조건 찾기
     private OperatingCondition findOperatingConditionOfPlace(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek, Place place) {
         OperatingCondition operatingCondition  = operatingConditionRepository.findByDayOfWeekAndIsHolidayAndIsVacationAndPlace(dayOfWeek, isHoliday, isVacation, place);
 
@@ -157,41 +201,32 @@ public class OperatingService {
         return operatingCondition;
     }
 
+    // 오늘에 맞는 운영 조건 목록 찾기
     private List<OperatingCondition> findOperatingConditionList(DayOfWeek dayOfWeek, boolean isHoliday, boolean isVacation, boolean isEvenWeek) {
         List<OperatingCondition> operatingConditionList  = operatingConditionRepository.findByDayOfWeekAndIsHolidayAndIsVacationOrNot(dayOfWeek, isHoliday, isVacation);
 
         if(dayOfWeek == DayOfWeek.SATURDAY) { // 토요일인 경우
             if(isEvenWeek) {
-                operatingConditionList.stream().filter(operatingCondition ->
-                    operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek());
+                operatingConditionList = operatingConditionList.stream().filter(operatingCondition ->
+                    operatingCondition.getIsEvenWeek() == null || operatingCondition.getIsEvenWeek()).toList();
             }
             else {
-                operatingConditionList.stream().filter(operatingCondition ->
-                    operatingCondition.getIsEvenWeek() == null || !operatingCondition.getIsEvenWeek());
+                operatingConditionList = operatingConditionList.stream().filter(operatingCondition ->
+                    operatingCondition.getIsEvenWeek() == null || !operatingCondition.getIsEvenWeek()).toList();
             }
         }
 
         return operatingConditionList;
     }
 
-    // 운영 조건으로 운영 여부 확인
-    private boolean checkIsOperating(OperatingCondition operatingCondition, LocalTime now) {
+    // 현재가 운영 시간에 포함되는지 판단
+    private boolean isInOperatingTime(LocalTime now, OperatingTime operatingTime) {
         int hour = now.getHour();
         int minute = now.getMinute();
-        log.info("hour: {}", hour);
-        log.info("minute: {}", minute);
 
-        List<OperatingTime> operatingTimeList = operatingTimeRepository.findAllByOperatingCondition(operatingCondition);
-
-        // 운영 여부 판단
-        for(OperatingTime operatingTime : operatingTimeList) {
-            if((hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
-                (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
-                (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute())) {
-                return true;
-            }
-        }
-        return false;
+        return (hour > operatingTime.getStartHour() && hour < operatingTime.getEndHour()) ||
+            (hour == operatingTime.getStartHour() && minute >= operatingTime.getStartMinute()) ||
+            (hour == operatingTime.getEndHour() && minute < operatingTime.getEndMinute());
     }
 
     private String formatTimeRange(LocalTime start, LocalTime end) {

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/entity/SuggestionType.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/entity/SuggestionType.java
@@ -13,9 +13,9 @@ public enum SuggestionType {
     INCORRECT_ROUTE("잘못된 경로 안내"),
     ADDITIONAL_INFORMATION("추가하고 싶은 정보"),
     FUNCTIONAL_ERROR("기능 오류"),
-    FEATURE_SUGGESTION("기능 추가 요청"),
-    INCONVENIENCE("불편한 점"),
-    QUESTION("궁금한 점"),
+    FEATURE_SUGGESTION("추천 기능"),
+    INCONVENIENCE("불편 사항"),
+    QUESTION("질의 사항"),
     OTHER("기타");
     private final String type;
 }

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -49,7 +49,10 @@ public enum ResultCode {
     NOT_FOUND_IN_CATEGORY(HttpStatus.NOT_FOUND, 7004, "카테고리 내에 해당 즐겨찾기가 존재하지 않습니다."),
 
     // 건의함 8000번대
-    NOT_FOUND_SUGGESTION(HttpStatus.NOT_FOUND, 8000, "건의를 찾을 수 없습니다.")
+    NOT_FOUND_SUGGESTION(HttpStatus.NOT_FOUND, 8000, "건의를 찾을 수 없습니다."),
+
+    // 운영 시간 10000번대
+    OPER_CONDITION_HAS_NO_OPER_TIME(HttpStatus.NOT_FOUND, 10000, "운영 조건이 운영 시간을 가지고 있지 않습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 개요
next time의 경우 중간에 쉬는 시간이 있는 경우를 반영하지 못해서 수정

## 작업사항
- 스케줄러가 낮 동안에는 10분마다, 밤에는 30분마다 작동하도록 수정
- 중간에 쉬는 시간이 있는 경우 next time을 다시 시작하는 시간, 다음 쉬는 시간 등을 반환할 수 있도록 운영 조건이 있는 장소의 operatingtime을 주기적으로 수정하도록 변경
- 건의 종류 수정

## 관련 이슈
- 
