### PR TITLE
User 관련 기능 추가 및 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/oauth2/service/OAuth2Service.java
+++ b/src/main/java/devkor/com/teamcback/domain/oauth2/service/OAuth2Service.java
@@ -6,29 +6,21 @@ import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.security.UserDetailsImpl;
 import jakarta.transaction.Transactional;
-import java.security.Principal;
-import java.util.Collections;
-import java.util.Map;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
 public class OAuth2Service extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
-
-    @Value("${default.image.url}")
-    private String defaultProfileImageUrl;
 
     private static final String DEFAULT_NAME = "호랑이";
 
@@ -62,8 +54,7 @@ public class OAuth2Service extends DefaultOAuth2UserService {
     }
 
     private User save(OAuth2UserInfo oAuth2UserInfo) {
-        User user = new User(makeRandomName(), oAuth2UserInfo.getEmail(), defaultProfileImageUrl, Role.USER, oAuth2UserInfo.getProvider(), 0L);
-
+        User user = new User(makeRandomName(), oAuth2UserInfo.getEmail(), Role.USER, oAuth2UserInfo.getProvider(), 0L);
         return userRepository.save(user);
     }
 

--- a/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @PostMapping()
+    @PatchMapping()
     public CommonResponse<ModifyUsernameRes> modifyUsername(
         @Parameter(description = "사용자정보", required = true)
         @AuthenticationPrincipal UserDetailsImpl userDetail,

--- a/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.user.controller;
 
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
+import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
 import devkor.com.teamcback.domain.user.service.UserService;
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.security.UserDetailsImpl;
@@ -12,9 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,5 +36,25 @@ public class UserController {
         @Parameter(description = "사용자정보", required = true)
         @AuthenticationPrincipal UserDetailsImpl userDetail) {
         return CommonResponse.success(userService.getUserInfo(userDetail.getUser().getUserId()));
+    }
+
+    /**
+     * 사용자 별명 수정
+     * @param userDetail 사용자 정보
+     * @param username 새로운 사용자명
+     */
+    @Operation(summary = "사용자 별명 수정", description = "사용자 별명 수정")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "Not Found",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @PostMapping()
+    public CommonResponse<ModifyUsernameRes> modifyUsername(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "사용자명", required = true)
+        @RequestParam String username) {
+        return CommonResponse.success(userService.modifyUsername(userDetail.getUser().getUserId(), username));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
@@ -2,8 +2,8 @@ package devkor.com.teamcback.domain.user.controller;
 
 import devkor.com.teamcback.domain.user.dto.request.LoginUserReq;
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
-import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
 import devkor.com.teamcback.domain.user.dto.response.LoginUserRes;
+import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
 import devkor.com.teamcback.domain.user.service.UserService;
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.security.UserDetailsImpl;

--- a/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @PatchMapping()
+    @PatchMapping("/username")
     public CommonResponse<ModifyUsernameRes> modifyUsername(
         @Parameter(description = "사용자정보", required = true)
         @AuthenticationPrincipal UserDetailsImpl userDetail,

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
@@ -1,6 +1,5 @@
 package devkor.com.teamcback.domain.user.dto.response;
 
-import devkor.com.teamcback.domain.user.entity.Level;
 import devkor.com.teamcback.domain.user.entity.Provider;
 import devkor.com.teamcback.domain.user.entity.Role;
 import devkor.com.teamcback.domain.user.entity.User;

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
@@ -21,12 +21,12 @@ public class GetUserInfoRes {
     @Schema(description = "role", example = "USER")
     private Role role;
     @Schema(description = "level", example = "1")
-    private Level level;
+    private int level;
     @Schema(description = "categoryCount", example = "2")
     private Long categoryCount;
     //TODO: 이웃 수, 게시물 수 정보 추가하기
 
-    public GetUserInfoRes(User user, Long categoryCount, Level level, String profileUrl) {
+    public GetUserInfoRes(User user, Long categoryCount, int level, String profileUrl) {
         this.username = user.getUsername();
         this.email = user.getEmail();
         this.profileUrl = profileUrl;

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
@@ -1,6 +1,5 @@
 package devkor.com.teamcback.domain.user.dto.response;
 
-import devkor.com.teamcback.domain.user.entity.Level;
 import devkor.com.teamcback.domain.user.entity.Provider;
 import devkor.com.teamcback.domain.user.entity.Role;
 import devkor.com.teamcback.domain.user.entity.User;
@@ -22,6 +21,8 @@ public class GetUserInfoRes {
     private Role role;
     @Schema(description = "level", example = "1")
     private int level;
+    @Schema(description = "score", example = "15")
+    private Long score;
     @Schema(description = "categoryCount", example = "2")
     private Long categoryCount;
     //TODO: 이웃 수, 게시물 수 정보 추가하기
@@ -33,6 +34,7 @@ public class GetUserInfoRes {
         this.provider = user.getProvider();
         this.role = user.getRole();
         this.level = level;
+        this.score = user.getScore();
         this.categoryCount = categoryCount;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
@@ -7,9 +7,6 @@ import devkor.com.teamcback.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-import java.util.Arrays;
-import java.util.Comparator;
-
 @Getter
 @Schema(description = "마이페이지 정보")
 public class GetUserInfoRes {
@@ -29,21 +26,13 @@ public class GetUserInfoRes {
     private Long categoryCount;
     //TODO: 이웃 수, 게시물 수 정보 추가하기
 
-    public GetUserInfoRes(User user, Long categoryCount) {
+    public GetUserInfoRes(User user, Long categoryCount, Level level, String profileUrl) {
         this.username = user.getUsername();
         this.email = user.getEmail();
-        this.profileUrl = user.getProfileUrl();
+        this.profileUrl = profileUrl;
         this.provider = user.getProvider();
         this.role = user.getRole();
-        this.level = calculateLevel(user.getScore());
+        this.level = level;
         this.categoryCount = categoryCount;
-    }
-
-    private Level calculateLevel(Long score) {
-        // score >= minScore 인 경우 중 가장 높은 레벨 반환
-        return Arrays.stream(Level.values())
-            .filter(level -> score >= level.getMinScore())
-            .max(Comparator.comparingInt(Level::getMinScore))
-            .orElse(Level.LEVEL1);
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/ModifyUsernameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/ModifyUsernameRes.java
@@ -3,7 +3,7 @@ package devkor.com.teamcback.domain.user.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "유저명 수정 완료")
+@Schema(description = "사용자명 수정 완료")
 @JsonIgnoreProperties
 public class ModifyUsernameRes {
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/ModifyUsernameRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/ModifyUsernameRes.java
@@ -1,0 +1,9 @@
+package devkor.com.teamcback.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저명 수정 완료")
+@JsonIgnoreProperties
+public class ModifyUsernameRes {
+}

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/Level.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/Level.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Level {
-    LEVEL1(0), // 0~4점
-    LEVEL2(5), // 5~14점
-    LEVEL3(15), //15~24점
-    LEVEL4(25), //25~34점
-    LEVEL5(35); //35점 이상
+    LEVEL1(0, 1, ProfileImage.getUrlByLevel(1)), // 0~4점
+    LEVEL2(5, 2, ProfileImage.getUrlByLevel(2)), // 5~14점
+    LEVEL3(15, 3, ProfileImage.getUrlByLevel(3)), //15~24점
+    LEVEL4(25, 4, ProfileImage.getUrlByLevel(4)), //25~34점
+    LEVEL5(35, 5, ProfileImage.getUrlByLevel(5)), ; //35점 이상
     private final int minScore;
+    private final int levelNumber;
+    private final String profileImage;
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/ProfileImage.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/ProfileImage.java
@@ -1,0 +1,42 @@
+package devkor.com.teamcback.domain.user.entity;
+
+import devkor.com.teamcback.global.exception.GlobalException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static devkor.com.teamcback.global.response.ResultCode.INCORRECT_LEVEL;
+
+@Component
+public class ProfileImage {
+    @Value("${profile.image.lv1-url}")
+    private String lv1Url;
+
+    @Value("${profile.image.lv2-url}")
+    private String lv2Url;
+
+    @Value("${profile.image.lv3-url}")
+    private String lv3Url;
+
+    @Value("${profile.image.lv4-url}")
+    private String lv4Url;
+
+    @Value("${profile.image.lv5-url}")
+    private String lv5Url;
+
+    private static ProfileImage profileImage;
+
+    public ProfileImage() {
+        profileImage = this;
+    }
+
+    public static String getUrlByLevel(int level) {
+        return switch (level) {
+            case 1 -> profileImage.lv1Url;
+            case 2 -> profileImage.lv2Url;
+            case 3 -> profileImage.lv3Url;
+            case 4 -> profileImage.lv4Url;
+            case 5 -> profileImage.lv5Url;
+            default -> throw new GlobalException(INCORRECT_LEVEL);
+        };
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -1,14 +1,7 @@
 package devkor.com.teamcback.domain.user.entity;
 
 import devkor.com.teamcback.domain.common.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,9 +21,6 @@ public class User extends BaseEntity {
     private String email;
 
     @Column(nullable = false)
-    private String profileUrl;
-
-    @Column(nullable = false)
     private Role role;
 
     @Column(nullable = false)
@@ -40,10 +30,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Long score;
 
-    public User(String username, String email, String profileUrl, Role role, Provider provider, Long score) {
+    public User(String username, String email, Role role, Provider provider, Long score) {
         this.username = username;
         this.email = email;
-        this.profileUrl = profileUrl;
         this.role = role;
         this.provider = provider;
         this.score = score;

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package devkor.com.teamcback.domain.user.entity;
 
 import devkor.com.teamcback.domain.common.BaseEntity;
-import devkor.com.teamcback.domain.user.dto.request.LoginUserReq;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -37,4 +37,8 @@ public class User extends BaseEntity {
         this.provider = provider;
         this.score = score;
     }
+
+    public void update(String username) {
+        this.username = username;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -47,7 +47,6 @@ public class User extends BaseEntity {
         this.score = 0L;
     }
 
-
     public void update(String username) {
         this.username = username;
     }

--- a/src/main/java/devkor/com/teamcback/domain/user/repository/UserRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmail(String email);
+    User findByUsername(String username);
 
     boolean existsByUsername(String username);
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/repository/UserRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmail(String email);
-    User findByUsername(String username);
+    boolean existsByUsernameAndUserIdNot(String username, Long id);
 
     boolean existsByUsername(String username);
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -61,9 +61,7 @@ public class UserService {
      */
     @Transactional
     public ModifyUsernameRes modifyUsername(Long userId, String username) {
-        if(username.isEmpty()) {  // username이 입력되지 않은 경우
-            throw new GlobalException(EMPTY_USERNAME);
-        }
+        checkInvalidUsername(username);
 
         // 사용자명 사용 가능 여부 확인
         User user = findUser(userId);
@@ -72,6 +70,13 @@ public class UserService {
         user.update(username);
 
         return new ModifyUsernameRes();
+    }
+
+    private void checkInvalidUsername(String username) {
+        // username이 입력되지 않은 경우
+        if(username.isEmpty()) {
+            throw new GlobalException(EMPTY_USERNAME);
+        }
     }
 
     private void checkUsernameAvailability(User user, String username) {

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -2,12 +2,17 @@ package devkor.com.teamcback.domain.user.service;
 
 import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
+import devkor.com.teamcback.domain.user.entity.Level;
 import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Comparator;
 
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
 
@@ -18,12 +23,45 @@ public class UserService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
 
+    // profile 이미지 링크
+    @Value("${profile.image.lv1-url}")
+    private String lv1Url;
+    @Value("${profile.image.lv2-url}")
+    private String lv2Url;
+    @Value("${profile.image.lv3-url}")
+    private String lv3Url;
+    @Value("${profile.image.lv4-url}")
+    private String lv4Url;
+    @Value("${profile.image.lv5-url}")
+    private String lv5Url;
+
     /**
      * 마이페이지 정보 조회
      */
     public GetUserInfoRes getUserInfo(Long userId) {
         User user = findUser(userId);
-        return new GetUserInfoRes(user, categoryRepository.countAllByUser(user));
+        Level level = getLevel(user.getScore());
+
+        return new GetUserInfoRes(user, categoryRepository.countAllByUser(user), level, getProfileUrl(level));
+    }
+
+    private Level getLevel(Long score) {
+        // score >= minScore 인 경우 중 가장 높은 레벨 반환
+        return Arrays.stream(Level.values())
+            .filter(level -> score >= level.getMinScore())
+            .max(Comparator.comparingInt(Level::getMinScore))
+            .orElse(Level.LEVEL1);
+    }
+
+    private String getProfileUrl(Level level) {
+        //레벨에 맞는 profile 이미지 반환
+        return switch (level) {
+            case LEVEL1 -> lv1Url;
+            case LEVEL2 -> lv2Url;
+            case LEVEL3 -> lv3Url;
+            case LEVEL4 -> lv4Url;
+            case LEVEL5 -> lv5Url;
+        };
     }
 
     private User findUser(Long userId) {

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -1,19 +1,16 @@
 package devkor.com.teamcback.domain.user.service;
 
 import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
-import devkor.com.teamcback.domain.oauth2.dto.OAuth2UserInfo;
 import devkor.com.teamcback.domain.user.dto.request.LoginUserReq;
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
+import devkor.com.teamcback.domain.user.dto.response.LoginUserRes;
 import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
 import devkor.com.teamcback.domain.user.entity.Level;
-import devkor.com.teamcback.domain.user.dto.response.LoginUserRes;
 import devkor.com.teamcback.domain.user.entity.Role;
 import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
 import devkor.com.teamcback.global.jwt.JwtUtil;
-import devkor.com.teamcback.global.response.CommonResponse;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.UUID;
 
 import static devkor.com.teamcback.global.response.ResultCode.*;
 

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -21,6 +21,8 @@ public enum ResultCode {
 
     // 사용자 2000번대
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2000, "사용자를 찾을 수 없습니다."),
+    DUPLICATED_USERNAME(HttpStatus.IM_USED, 2001, "이미 사용 중인 별명입니다."),
+    USERNAME_IN_USE(HttpStatus.IM_USED, 2002, "현재 설정된 별명과 다른 별명을 입력해주세요."),
 
     // 건물 3000번대
     NOT_FOUND_BUILDING(HttpStatus.NOT_FOUND, 3000, "건물을 찾을 수 없습니다."),

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -23,6 +23,7 @@ public enum ResultCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2000, "사용자를 찾을 수 없습니다."),
     DUPLICATED_USERNAME(HttpStatus.IM_USED, 2001, "이미 사용 중인 별명입니다."),
     USERNAME_IN_USE(HttpStatus.IM_USED, 2002, "현재 설정된 별명과 다른 별명을 입력해주세요."),
+    INCORRECT_LEVEL(HttpStatus.BAD_REQUEST, 2003, "존재하지 않는 레벨입니다."),
 
     // 건물 3000번대
     NOT_FOUND_BUILDING(HttpStatus.NOT_FOUND, 3000, "건물을 찾을 수 없습니다."),

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -24,6 +24,7 @@ public enum ResultCode {
     DUPLICATED_USERNAME(HttpStatus.IM_USED, 2001, "이미 사용 중인 별명입니다."),
     USERNAME_IN_USE(HttpStatus.IM_USED, 2002, "현재 설정된 별명과 다른 별명을 입력해주세요."),
     INCORRECT_LEVEL(HttpStatus.BAD_REQUEST, 2003, "존재하지 않는 레벨입니다."),
+    EMPTY_USERNAME(HttpStatus.BAD_REQUEST, 2004, "별명을 입력해주세요."),
 
     // 건물 3000번대
     NOT_FOUND_BUILDING(HttpStatus.NOT_FOUND, 3000, "건물을 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
- 사용자명 수정 기능 추가
- 프로필 이미지 관련 수정
- 마이페이지 정보 조회 시 level의 반환타입을 int로 수정 (FE 요청)

## 작업사항
<사용자명>
- 빈 스트링 / 다른 사용자가 사용중인 별명 / 본인의 기존 별명과 동일한 별명을 받은 경우 예외가 발생합니다.

<프로필 이미지>
- application.yml에 각 레벨 이미지 경로를 추가하였습니다. 자세한 사항은 BE 관련 명세의 해당 부분을 참고해주세요!
![image](https://github.com/user-attachments/assets/78cd4595-6a6c-4f64-a08b-c2e292846874)
- 각 레벨별 프로필 이미지는 제가 임시로 그려서 넣어뒀습니다. 나중에 디자인 완성되면 수정하겠습니다!
- level과 관련된 계산 로직들을 모두 UserService 파일로 이동시켰습니다.
- Bean과 관련된 문제가 있어서 아예 profileUrl을 받아오는 class를 따로 생성하였습니다!

## 관련 이슈
- tb_user의 profileUrl을 삭제하니까 로그인에 오류가 생겨서 해당 PR을 머지한 후에 제거하도록 하겠습니다. User Entity의 생성자가 달라서 오류가 발생하는 것 같아요!