### PR TITLE
Fix: bookmark 추가에 따른 User Score 증가 로직 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
@@ -12,7 +12,7 @@ public class CreateBookmarkReq {
     private LocationType locationType;
 
     @Schema(description = "장소 id", example = "5")
-    private Long placeId;
+    private Long locationId;
 
     @Schema(description = "카테고리 메모", example = "자주 찾는 장소 모음")
     private String memo;

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetBookmarkRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetBookmarkRes.java
@@ -15,7 +15,7 @@ public class GetBookmarkRes {
     private LocationType locationType;
 
     @Schema(description = "즐겨찾기 장소 Id", example = "5")
-    private Long placeId;
+    private Long locationId;
 
     @Schema(description = "즐겨찾기 메모", example = "자료구조 강의실")
     private String memo;
@@ -23,7 +23,7 @@ public class GetBookmarkRes {
     public GetBookmarkRes(Bookmark bookmark) {
         this.bookmarkId = bookmark.getId();
         this.locationType = bookmark.getLocationType();
-        this.placeId = bookmark.getPlaceId();
+        this.locationId = bookmark.getLocationId();
         this.memo = bookmark.getMemo();
     }
 

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
@@ -25,7 +25,7 @@ public class Bookmark extends BaseEntity {
     private LocationType locationType;
 
     @Column(nullable = false)
-    private Long placeId;
+    private Long locationId;
 
     @Column
     private String memo;
@@ -35,7 +35,7 @@ public class Bookmark extends BaseEntity {
         this.category = category;
         this.memo = req.getMemo();
         this.locationType = req.getLocationType();
-        this.placeId = req.getPlaceId();
+        this.locationId = req.getLocationId();
 
     }
 

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/UserBookmarkLog.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/UserBookmarkLog.java
@@ -1,0 +1,36 @@
+package devkor.com.teamcback.domain.bookmark.entity;
+
+import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tb_user_bookmark_log")
+@NoArgsConstructor
+public class UserBookmarkLog {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private Long locationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LocationType locationType;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    public UserBookmarkLog (Long locationId, LocationType locationType, User user) {
+        this.locationId = locationId;
+        this.locationType = locationType;
+        this.user = user;
+    }
+
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
-    Optional<Bookmark> findByCategoryAndLocationTypeAndPlaceId(Category category, LocationType locationType, Long placeId);
+    Optional<Bookmark> findByCategoryAndLocationTypeAndLocationId(Category category, LocationType locationType, Long locationId);
     Long countAllByCategory(Category category);
     List<Bookmark> findAllByCategory(Category category);
-    Boolean existsByLocationTypeAndPlaceIdAndCategoryIn(LocationType locationType, Long placeId, List<Category> category);
+    Boolean existsByLocationTypeAndLocationIdAndCategoryIn(LocationType locationType, Long locationId, List<Category> category);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/UserBookmarkLogRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/UserBookmarkLogRepository.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.bookmark.repository;
+
+import devkor.com.teamcback.domain.bookmark.entity.UserBookmarkLog;
+import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBookmarkLogRepository extends JpaRepository<UserBookmarkLog, Long> {
+    boolean existsByUserAndLocationIdAndLocationType(User user, Long locationId, LocationType locationType);
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
@@ -128,11 +128,11 @@ public class CategoryService {
         checkAuthority(user, category.getUser());
 
         //placeType & Id로 장소 존재 여부 확인
-        checkPlaceExists(req.getLocationType(), req.getPlaceId());
+        checkPlaceExists(req.getLocationType(), req.getLocationId());
 
         //장소 중복 확인하기
         //해당 카테고리안에 placeType, placeId가 모두 동일한 것이 있으면 중복
-        checkPlaceDuplication(category, req.getLocationType(), req.getPlaceId());
+        checkPlaceDuplication(category, req.getLocationType(), req.getLocationId());
 
         //즐겨찾기 생성
         Bookmark bookmark = bookmarkRepository.save(new Bookmark(req, category));
@@ -214,7 +214,7 @@ public class CategoryService {
     }
 
     private void checkPlaceDuplication(Category category, LocationType locationType, Long placeId) {
-        Optional<Bookmark> optionalBookmark = bookmarkRepository.findByCategoryAndLocationTypeAndPlaceId(category, locationType, placeId);
+        Optional<Bookmark> optionalBookmark = bookmarkRepository.findByCategoryAndLocationTypeAndLocationId(category, locationType, placeId);
 
         // 같은 카테고리에 동일 북마크가 존재하는 경우
         if (optionalBookmark.isPresent()) {

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -259,7 +259,7 @@ public class SearchService {
             User user = findUser(userId);
             // 해당 유저의 북마크에 빌딩 있는지 확인 (유저의 카테고리 리스트 가져와서, 해당 안에 존재하는지 확인)
             List<Category> categories = categoryRepository.findAllByUser(user);
-            if(bookmarkRepository.existsByLocationTypeAndPlaceIdAndCategoryIn(LocationType.BUILDING, buildingId, categories)) {
+            if(bookmarkRepository.existsByLocationTypeAndLocationIdAndCategoryIn(LocationType.BUILDING, buildingId, categories)) {
                 bookmarked = true;
             }
         }
@@ -284,7 +284,7 @@ public class SearchService {
         }
 
         Place place = findPlace(placeId);
-        if(bookmarkRepository.existsByLocationTypeAndPlaceIdAndCategoryIn(LocationType.PLACE, place.getId(), categories)) {
+        if(bookmarkRepository.existsByLocationTypeAndLocationIdAndCategoryIn(LocationType.PLACE, place.getId(), categories)) {
             bookmarked = true;
         }
         return new SearchPlaceDetailRes(place, bookmarked, placeImageRepository.findAllByPlace(place).stream().map(SearchPlaceImageRes::new).toList());

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
@@ -33,13 +33,17 @@ public class SuggestionController {
     @Operation(summary = "건의 작성", description = "건의 작성")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
         @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     @PostMapping
     public CommonResponse<CreateSuggestionRes> createSuggestion(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
         @Parameter(description = "건의 제목, 분류, 내용", required = true)
         @RequestBody CreateSuggestionReq req) {
-        return CommonResponse.success(suggestionService.createSuggestion(req));
+        return CommonResponse.success(suggestionService.createSuggestion(userDetail.getUser().getUserId(), req));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/dto/response/GetSuggestionRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/dto/response/GetSuggestionRes.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.suggestion.dto.response;
 
 import devkor.com.teamcback.domain.suggestion.entity.Suggestion;
+import devkor.com.teamcback.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.format.DateTimeFormatter;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class GetSuggestionRes {
     private String title;
     private String type;
     private String content;
+    private Long userId;
     private String createdAt;
     private boolean isSolved;
 
@@ -23,5 +25,6 @@ public class GetSuggestionRes {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
         this.createdAt = suggestion.getCreatedAt().format(formatter);
         this.isSolved = suggestion.isSolved();
+        this.userId = suggestion.getUser().getUserId();
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/entity/Suggestion.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/entity/Suggestion.java
@@ -3,14 +3,8 @@ package devkor.com.teamcback.domain.suggestion.entity;
 import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
 import devkor.com.teamcback.domain.common.BaseEntity;
 import devkor.com.teamcback.domain.suggestion.dto.request.CreateSuggestionReq;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import devkor.com.teamcback.domain.user.entity.User;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,12 +30,15 @@ public class Suggestion extends BaseEntity {
     @Column(nullable = false)
     private boolean isSolved = false;
 
-    // TODO: 로그인 개발 이후 User와 다대일 연관관계
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
 
-    public Suggestion(CreateSuggestionReq req) {
+    public Suggestion(CreateSuggestionReq req, User user) {
         this.title = req.getTitle();
         this.suggestionType = req.getType();
         this.content = req.getContent();
+        this.user = user;
     }
 
     public void updateIsSolved(boolean solved) {

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
@@ -29,6 +29,7 @@ public class SuggestionService {
      */
     @Transactional
     public CreateSuggestionRes createSuggestion(CreateSuggestionReq req) {
+        // TODO: 건의 생성 시 user의 score += 3
         Suggestion suggestion = new Suggestion(req);
 
         Suggestion savedSuggestion = suggestionRepository.save(suggestion);

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.suggestion.service;
 
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_SUGGESTION;
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
 
 import devkor.com.teamcback.domain.suggestion.dto.request.CreateSuggestionReq;
 import devkor.com.teamcback.domain.suggestion.dto.response.CreateSuggestionRes;
@@ -9,6 +10,8 @@ import devkor.com.teamcback.domain.suggestion.dto.response.ModifySuggestionRes;
 import devkor.com.teamcback.domain.suggestion.entity.Suggestion;
 import devkor.com.teamcback.domain.suggestion.entity.SuggestionType;
 import devkor.com.teamcback.domain.suggestion.repository.SuggestionRepository;
+import devkor.com.teamcback.domain.user.entity.User;
+import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,16 +26,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SuggestionService {
     private final SuggestionRepository suggestionRepository;
+    private final UserRepository userRepository;
 
     /**
      * 건의 생성
      */
     @Transactional
-    public CreateSuggestionRes createSuggestion(CreateSuggestionReq req) {
-        // TODO: 건의 생성 시 user의 score += 3
-        Suggestion suggestion = new Suggestion(req);
+    public CreateSuggestionRes createSuggestion(Long userId, CreateSuggestionReq req) {
+        User user = findUser(userId);
+        Suggestion suggestion = new Suggestion(req, user);
 
         Suggestion savedSuggestion = suggestionRepository.save(suggestion);
+
+        //건의 생성 시 score 증가
+        user.updateScore(user.getScore() + 3);
 
         return new CreateSuggestionRes(savedSuggestion);
     }
@@ -71,5 +78,9 @@ public class SuggestionService {
 
     private Suggestion findSuggestion(Long id) {
         return suggestionRepository.findById(id).orElseThrow(() ->new GlobalException(NOT_FOUND_SUGGESTION));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new GlobalException(NOT_FOUND_USER));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/Level.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/Level.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Level {
     LEVEL1(0, 1, ProfileImage.getUrlByLevel(1)), // 0~4점
-    LEVEL2(5, 2, ProfileImage.getUrlByLevel(2)), // 5~14점
-    LEVEL3(15, 3, ProfileImage.getUrlByLevel(3)), //15~24점
-    LEVEL4(25, 4, ProfileImage.getUrlByLevel(4)), //25~34점
-    LEVEL5(35, 5, ProfileImage.getUrlByLevel(5)), ; //35점 이상
+    LEVEL2(5, 2, ProfileImage.getUrlByLevel(2)), // 5~19점
+    LEVEL3(20, 3, ProfileImage.getUrlByLevel(3)), //20~39점
+    LEVEL4(40, 4, ProfileImage.getUrlByLevel(4)), //40~59점
+    LEVEL5(60, 5, ProfileImage.getUrlByLevel(5)), ; //60점 이상
     private final int minScore;
     private final int levelNumber;
     private final String profileImage;

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -46,7 +46,10 @@ public class User extends BaseEntity {
         this.score = 0L;
     }
 
-    public void update(String username) {
+    public void updateUsername(String username) {
         this.username = username;
+    }
+    public void updateScore(Long score) {
+        this.score = score;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
         User user = findUser(userId);
         checkUsernameAvailability(user, username);
 
-        user.update(username);
+        user.updateUsername(username);
 
         return new ModifyUsernameRes();
     }


### PR DESCRIPTION
## 개요
- level 기준 점수 수정
-  bookmark 추가 시 User Score 증가 (+1점)
- tb_bookmark의 placeId 컬럼/변수를 locationId로 수정했습니다 (혼란 방지용)
- tb_suggestion에 userId 추가

## 작업사항
- 즐겨찾기 취소에 대한 점수 회수는 없지만, 동일 건물/시설물에 대한 즐겨찾기 점수 상승은 1회만 가능.
- 동일 건물에 대해 취소했다 다시 즐겨찾기해도 추가 점수상승 없음
- tb_user_bookmark_log에 관련 정보 저장하는 방식을 사용했습니다

- 건의 생성 시 로그인 필요, 점수 3점 증가
- 전체 건의 조회 시 userId도 조회 가능
