### PR TITLE
Operating time 시간 타입 변경

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingTime.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingTime.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,10 @@ public class OperatingTime {
 
     @Column(nullable = false)
     private int endMinute;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
 
     @ManyToOne
     @JoinColumn(name = "operating_condition_id")

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingTime.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/OperatingTime.java
@@ -23,19 +23,9 @@ public class OperatingTime {
     private Long id;
 
     @Column(nullable = false)
-    private int startHour;
-
-    @Column(nullable = false)
-    private int startMinute;
-
-    @Column(nullable = false)
-    private int endHour;
-
-    @Column(nullable = false)
-    private int endMinute;
-
     private LocalTime startTime;
 
+    @Column(nullable = false)
     private LocalTime endTime;
 
     @ManyToOne

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/sceduler/OperatingScheduler.java
@@ -39,8 +39,13 @@ public class OperatingScheduler {
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정마다
     @EventListener(ApplicationReadyEvent.class)
     public void updateOperatingTime() {
-        log.info("운영 시간 업데이트");
+        setState();
 
+        log.info("운영 시간 업데이트");
+        operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
+    }
+
+    private void setState() {
         LocalDate now = LocalDate.now();
 
         dayOfWeek = findDayOfWeek(now);
@@ -54,8 +59,6 @@ public class OperatingScheduler {
             isEvenWeek = isEvenWeek(now);
             log.info("isEvenWeek: {}", isEvenWeek);
         }
-
-        operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
     }
 
 //    @Scheduled(cron = "30 16 * * * *") // 테스트용

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/Place.java
@@ -1,5 +1,7 @@
 package devkor.com.teamcback.domain.place.entity;
 
+import static devkor.com.teamcback.domain.operatingtime.service.OperatingService.OPERATING_TIME_PATTERN;
+
 import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.place.dto.request.CreatePlaceReq;
 import devkor.com.teamcback.domain.place.dto.request.ModifyPlaceReq;
@@ -7,6 +9,7 @@ import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.common.BaseEntity;
 import devkor.com.teamcback.domain.routes.entity.Node;
 import jakarta.persistence.*;
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -124,7 +127,7 @@ public class Place extends BaseEntity {
             case WEEKDAY -> this.operatingTime = weekdayOperatingTime;
         }
 
-        if(this.operatingTime == null) {
+        if(this.operatingTime == null || !Pattern.matches(OPERATING_TIME_PATTERN, operatingTime)) {
             this.operatingTime = this.building.getOperatingTime();
         }
     }


### PR DESCRIPTION
## 개요
Operating time의 운영 시작 시간, 종료 시간의 타입을 int -> localTime으로 수정

## 작업사항
- Operating time의 운영 시작 시간, 종료 시간의 타입을 int -> localTime으로 수정
- 장소의 operatingTime이 "00:00-00:00"형식이 아닌 문자열인 경우 building의 operatingTime을 가져오도록 수정

## 관련 이슈
- 해당 PR 머지 후 operatingTime의 기존 필드를 삭제할 예정입니다.
