### PR TITLE
Fix:search 중복 제거

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -194,8 +194,6 @@ public class SearchService {
 
          List<SearchRoomDetailRes> roomDetailRes = new ArrayList<>(
              placeList.stream().map(SearchRoomDetailRes::new).toList());
-         roomDetailRes.addAll(placeList.stream().map(SearchRoomDetailRes::new).toList());
-
          return new SearchRoomRes(roomDetailRes);
     }
 


### PR DESCRIPTION
## 개요
buildings/{buildingId}/floor/{floor}/rooms
- 동일 코드가 두번 들어있어서 제거하였습니다.
