### PR TITLE
Fix: 건물 다음 운영 시간을 찾는 로직 오류 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/DayOfWeek.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/entity/DayOfWeek.java
@@ -1,10 +1,63 @@
 package devkor.com.teamcback.domain.operatingtime.entity;
 
+import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.place.entity.Place;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum DayOfWeek {
-    WEEKDAY, SATURDAY, SUNDAY;
+    WEEKDAY {
+        @Override
+        public DayOfWeek findNext() {
+            return SATURDAY;
+        }
+
+        @Override
+        public String getOperatingTime(Building building) {
+            return building.getWeekdayOperatingTime();
+        }
+
+        @Override
+        public String getOperatingTime(Place place) {
+            return place.getWeekdayOperatingTime();
+        }
+    },
+    SATURDAY {
+        @Override
+        public DayOfWeek findNext() {
+            return SUNDAY;
+        }
+
+        @Override
+        public String getOperatingTime(Building building) {
+            return building.getSaturdayOperatingTime();
+        }
+
+        @Override
+        public String getOperatingTime(Place place) {
+            return place.getSaturdayOperatingTime();
+        }
+    },
+    SUNDAY {
+        @Override
+        public DayOfWeek findNext() {
+            return WEEKDAY;
+        }
+
+        @Override
+        public String getOperatingTime(Building building) {
+            return building.getSundayOperatingTime();
+        }
+
+        @Override
+        public String getOperatingTime(Place place) {
+            return place.getSundayOperatingTime();
+        }
+    };
+
+    public abstract DayOfWeek findNext();
+    public abstract String getOperatingTime(Building building);
+    public abstract String getOperatingTime(Place place);
 }

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/HolidayScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/HolidayScheduler.java
@@ -1,4 +1,4 @@
-package devkor.com.teamcback.domain.operatingtime.sceduler;
+package devkor.com.teamcback.domain.operatingtime.scheduler;
 
 import devkor.com.teamcback.domain.operatingtime.service.HolidayService;
 import java.net.URISyntaxException;

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/OperatingScheduler.java
@@ -1,10 +1,9 @@
-package devkor.com.teamcback.domain.operatingtime.sceduler;
+package devkor.com.teamcback.domain.operatingtime.scheduler;
 
 import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.operatingtime.service.HolidayService;
 import devkor.com.teamcback.domain.operatingtime.service.OperatingService;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +45,7 @@ public class OperatingScheduler {
     }
 
 
-//    @Scheduled(cron = "30 16 * * * *") // 테스트용
+//    @Scheduled(cron = "30 35 * * * *") // 테스트용
     @Scheduled(cron = "0 */10 9-18 * * *") // 10분마다
     public void updateOperatingDuringPeakHour() {
         log.info("운영 여부 업데이트");

--- a/src/main/java/devkor/com/teamcback/domain/routes/entity/NodeType.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/entity/NodeType.java
@@ -10,7 +10,8 @@ public enum NodeType {
     ELEVATOR("엘리베이터"),
     STAIR("계단"),
     ENTRANCE("출입문"),
-    CHECKPOINT("경로");
+    CHECKPOINT("경로"),
+    SHUTTLE("셔틀");
 
     private final String name;
 }


### PR DESCRIPTION
## 개요
건물 다음 운영 시간을 찾는 로직 오류 수정
ex. 일요일 운영 시간이 시간 형식이 아닌 문자열일 때 : 평일이 아닌 토요일 운영 시간을 가져옴

## 작업사항
- 건물 다음 운영 시간을 찾는 로직 오류 수정
- 가독성을 위해 DayOfWeek enum 수정
- 길찾기 오류 방지를 위해 nodeType 수정
- 스케줄러 오타 수정
- 정보 없는 건물 리스트 추가

## 관련 이슈
- 
