### PR TITLE
카테고리 및 즐겨찾기 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,104 @@
+package devkor.com.teamcback.domain.bookmark.controller;
+
+import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.dto.request.ModifyBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.dto.response.CreateBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.dto.response.DeleteBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.dto.response.ModifyBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.service.BookmarkService;
+import devkor.com.teamcback.global.response.CommonResponse;
+import devkor.com.teamcback.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookmarks")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    /**
+     * 즐겨찾기 생성 or 수정
+     * @param userDetail 사용자정보
+     * @param req 즐겨찾기 생성을 위한 정보
+     */
+    @Operation(summary = "즐겨찾기 생성 또는 수정", description = "즐겨찾기 생성 또는 수정: 로그인 필요")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @PostMapping
+    public CommonResponse<CreateBookmarkRes> createCategory(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "장소타입, 장소 id (건물 or 강의실 or 편의시설), 메모", required = true)
+        @RequestBody CreateBookmarkReq req) {
+        return CommonResponse.success(bookmarkService.createBookmark(userDetail.getUser().getUserId(), req));
+    }
+
+    /**
+     * 즐겨찾기 삭제
+     * @param userDetail 사용자 정보
+     * @param bookmarkId 삭제할 즐겨찾기 id
+     */
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 삭제: 로그인 필요")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @DeleteMapping("/{bookmarkId}")
+    public CommonResponse<DeleteBookmarkRes> deleteBookmark(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "즐겨찾기 id", required = true)
+        @PathVariable Long bookmarkId) {
+        return CommonResponse.success(bookmarkService.deleteBookmark(userDetail.getUser().getUserId(), bookmarkId));
+    }
+
+    /**
+     * 즐겨찾기 수정
+     * @param userDetail 사용자 정보
+     * @param bookmarkId 수정할 즐겨찾기 id
+     * @param req 즐겨찾기 메모 수정을 위한 정보
+     */
+    @Operation(summary = "즐겨찾기 수정", description = "즐겨찾기 수정: 로그인 필요")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @PutMapping("/{bookmarkId}")
+    public CommonResponse<ModifyBookmarkRes> modifyBookmark(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "즐겨찾기 id", required = true)
+        @PathVariable Long bookmarkId,
+        @Parameter(description = "수정된 메모", required = true)
+        @RequestBody ModifyBookmarkReq req) {
+        return CommonResponse.success(bookmarkService.modifyBookmark(userDetail.getUser().getUserId(), bookmarkId, req));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/controller/CategoryController.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/controller/CategoryController.java
@@ -1,10 +1,10 @@
 package devkor.com.teamcback.domain.bookmark.controller;
 
 import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
-import devkor.com.teamcback.domain.bookmark.dto.request.ModifyBookmarkReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.ModifyCategoryReq;
 import devkor.com.teamcback.domain.bookmark.dto.response.*;
 import devkor.com.teamcback.domain.bookmark.service.CategoryService;
+import devkor.com.teamcback.domain.common.LocationType;
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -140,8 +141,13 @@ public class CategoryController {
     @GetMapping
     public CommonResponse<GetCategoryListRes> getAllCategories(
         @Parameter(description = "사용자정보", required = true)
-        @AuthenticationPrincipal UserDetailsImpl userDetail) {
-        return CommonResponse.success(categoryService.getAllCategories(userDetail.getUser().getUserId()));
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "장소 종류")
+        @RequestParam LocationType type,
+        @Parameter(description = "장소 id")
+        @RequestParam Long id
+    ) {
+        return CommonResponse.success(categoryService.getAllCategories(userDetail.getUser().getUserId(), type, id));
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/controller/CategoryController.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/controller/CategoryController.java
@@ -1,6 +1,5 @@
 package devkor.com.teamcback.domain.bookmark.controller;
 
-import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.ModifyBookmarkReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.ModifyCategoryReq;
@@ -24,8 +23,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -153,7 +150,7 @@ public class CategoryController {
      * @param categoryId 카테고리 id
      * @return 즐겨찾기 List: [{즐겨찾기 id, 장소 타입, 장소 id, 메모}]
      */
-    @Operation(summary = "카테고리 전체 조회", description = "카테고리의 모든 즐겨찾기 조회: 로그인 필요")
+    @Operation(summary = "카테고리 내 즐겨찾기 목록 조회", description = "카테고리의 모든 즐겨찾기 조회: 로그인 필요")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
         @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
@@ -171,92 +168,12 @@ public class CategoryController {
     }
 
     /**
-     * 즐겨찾기 생성
-     * @param userDetail 사용자정보
-     * @param categoryId 카테고리 Id
-     * @param req 즐겨찾기 생성을 위한 정보
-     */
-    @Operation(summary = "즐겨찾기 생성", description = "특정 카테고리의 즐겨찾기 생성: 로그인 필요")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
-        @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-    })
-    @PostMapping("/{categoryId}/bookmarks")
-    public CommonResponse<CreateBookmarkRes> createCategory(
-        @Parameter(description = "사용자정보", required = true)
-        @AuthenticationPrincipal UserDetailsImpl userDetail,
-        @Parameter(description = "카테고리 id", required = true)
-        @PathVariable Long categoryId,
-        @Parameter(description = "장소타입, 장소 id (건물 or 강의실 or 편의시설), 메모", required = true)
-        @RequestBody CreateBookmarkReq req) {
-        return CommonResponse.success(categoryService.createBookmark(userDetail.getUser().getUserId(), categoryId, req));
-    }
-
-    /**
-     * 즐겨찾기 삭제
-     * @param userDetail 사용자 정보
-     * @param categoryId 삭제할 즐겨찾기가 속하는 카테고리 id
-     * @param bookmarkId 삭제할 즐겨찾기 id
-     */
-    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 삭제: 로그인 필요")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
-        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없습니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-    })
-    @DeleteMapping("/{categoryId}/bookmarks/{bookmarkId}")
-    public CommonResponse<DeleteBookmarkRes> deleteBookmark(
-        @Parameter(description = "사용자정보", required = true)
-        @AuthenticationPrincipal UserDetailsImpl userDetail,
-        @Parameter(description = "카테고리 id", required = true)
-        @PathVariable Long categoryId,
-        @Parameter(description = "즐겨찾기 id", required = true)
-        @PathVariable Long bookmarkId) {
-        return CommonResponse.success(categoryService.deleteBookmark(userDetail.getUser().getUserId(), categoryId, bookmarkId));
-    }
-
-    /**
-     * 즐겨찾기 수정
-     * @param userDetail 사용자 정보
-     * @param categoryId 카테고리 id
-     * @param bookmarkId 수정할 즐겨찾기 id
-     * @param req 즐겨찾기 메모 수정을 위한 정보
-     */
-    @Operation(summary = "즐겨찾기 수정", description = "즐겨찾기 수정: 로그인 필요")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
-        @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없습니다.",
-            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-    })
-    @PutMapping("/{categoryId}/bookmarks/{bookmarkId}")
-    public CommonResponse<ModifyBookmarkRes> modifyBookmark(
-        @Parameter(description = "사용자정보", required = true)
-        @AuthenticationPrincipal UserDetailsImpl userDetail,
-        @Parameter(description = "카테고리 id", required = true)
-        @PathVariable Long categoryId,
-        @Parameter(description = "즐겨찾기 id", required = true)
-        @PathVariable Long bookmarkId,
-        @Parameter(description = "수정된 메모", required = true)
-        @RequestBody ModifyBookmarkReq req) {
-        return CommonResponse.success(categoryService.modifyBookmark(userDetail.getUser().getUserId(), categoryId, bookmarkId, req));
-    }
-
-    /**
-     * 즐겨찾기 조회
+     * 카테고리 내 즐겨찾기 상세 조회
      * @param userDetail 사용자 정보
      * @param categoryId 카테고리 id
      * @return 즐겨찾기 id, 장소 타입, 장소 id, 메모
      */
-    @Operation(summary = "즐겨찾기 조회", description = "즐겨찾기 카테고리 조회: 로그인 필요")
+    @Operation(summary = "카테고리 내 즐겨찾기 상세 조회", description = "즐겨찾기 카테고리 조회: 로그인 필요")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
         @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
@@ -273,6 +190,31 @@ public class CategoryController {
         @Parameter(description = "즐겨찾기 id", required = true)
         @PathVariable Long bookmarkId) {
         return CommonResponse.success(categoryService.getBookmark(userDetail.getUser().getUserId(), categoryId, bookmarkId));
+    }
+
+    /**
+     * 카테고리 내 즐겨찾기 삭제
+     * @param userDetail 사용자 정보
+     * @param categoryId 삭제할 즐겨찾기가 속하는 카테고리 id
+     * @param bookmarkId 삭제할 즐겨찾기 id
+     */
+    @Operation(summary = "카테고리 내 즐겨찾기 삭제", description = "즐겨찾기 삭제: 로그인 필요")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "401", description = "권한이 없는 사용자입니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+        @ApiResponse(responseCode = "404", description = "즐겨찾기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @DeleteMapping("/{categoryId}/bookmarks/{bookmarkId}")
+    public CommonResponse<DeleteBookmarkRes> deleteBookmark(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail,
+        @Parameter(description = "카테고리 id", required = true)
+        @PathVariable Long categoryId,
+        @Parameter(description = "즐겨찾기 id", required = true)
+        @PathVariable Long bookmarkId) {
+        return CommonResponse.success(categoryService.deleteBookmark(userDetail.getUser().getUserId(), categoryId, bookmarkId));
     }
 
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
@@ -2,11 +2,14 @@ package devkor.com.teamcback.domain.bookmark.dto.request;
 
 import devkor.com.teamcback.domain.common.LocationType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Getter;
 
 @Schema(description = "장소타입, 장소 id (건물 or 강의실 or 편의시설), 메모")
 @Getter
 public class CreateBookmarkReq {
+    @Schema(description = "카테고리 id 리스트", example = "[1, 2, 3]")
+    private List<Long> categoryIdList;
 
     @Schema(description = "장소타입", example = "BUILDING")
     private LocationType locationType;

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
@@ -17,6 +17,6 @@ public class CreateBookmarkReq {
     @Schema(description = "장소 id", example = "5")
     private Long locationId;
 
-    @Schema(description = "카테고리 메모", example = "자주 찾는 장소 모음")
+    @Schema(description = "즐겨찾기 메모", example = "수업 장소")
     private String memo;
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/CreateBookmarkRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/CreateBookmarkRes.java
@@ -1,16 +1,10 @@
 package devkor.com.teamcback.domain.bookmark.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "즐겨찾기 생성 완료")
-@Getter
+@JsonIgnoreProperties
 public class CreateBookmarkRes {
-    @Schema(description = "즐겨찾기 id", example = "1")
-    private Long bookmarkId;
-
-    public CreateBookmarkRes(Bookmark bookmark) {
-        this.bookmarkId = bookmark.getId();
-    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryListRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryListRes.java
@@ -3,11 +3,18 @@ package devkor.com.teamcback.domain.bookmark.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Schema(description = "카테고리 목록 조회")
+@NoArgsConstructor
 public class GetCategoryListRes {
-    List<GetCategoryRes> categoryList;
+    @Schema(description = "사용자의 카테고리 목록")
+    private List<GetCategoryRes> categoryList;
+    @Schema(description = "장소가 즐겨찾기된 경우 즐겨찾기 id", example = "1")
+    @Setter
+    private Long bookmarkId = null;
 
     public GetCategoryListRes(List<GetCategoryRes> categoryList) {
         this.categoryList = categoryList;

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryRes.java
@@ -16,7 +16,7 @@ public class GetCategoryRes {
     @Schema(description = "카테고리 메모", example = "자주 찾는 장소 모음")
     private String memo;
     @Schema(description = "카테고리의 즐겨찾기 수", example = "5")
-    private Long bookmarkCount;
+    private int bookmarkCount;
 
     public GetCategoryRes(Category category) {
         this.categoryId = category.getId();
@@ -25,7 +25,7 @@ public class GetCategoryRes {
         this.memo = category.getMemo();
     }
 
-    public GetCategoryRes(Category category, Long bookmarkCount) {
+    public GetCategoryRes(Category category, int bookmarkCount) {
         this.categoryId = category.getId();
         this.category = category.getCategory();
         this.color = category.getColor().getName();

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/response/GetCategoryRes.java
@@ -17,6 +17,8 @@ public class GetCategoryRes {
     private String memo;
     @Schema(description = "카테고리의 즐겨찾기 수", example = "5")
     private int bookmarkCount;
+    @Schema(description = "장소가 즐겨찾기된 경우 카테고리 포함 여부", example = "true")
+    private boolean isBookmarked = false;
 
     public GetCategoryRes(Category category) {
         this.categoryId = category.getId();
@@ -31,5 +33,14 @@ public class GetCategoryRes {
         this.color = category.getColor().getName();
         this.memo = category.getMemo();
         this.bookmarkCount = bookmarkCount;
+    }
+
+    public GetCategoryRes(Category category, int bookmarkCount, boolean isBookmarked) {
+        this.categoryId = category.getId();
+        this.category = category.getCategory();
+        this.color = category.getColor().getName();
+        this.memo = category.getMemo();
+        this.bookmarkCount = bookmarkCount;
+        this.isBookmarked = isBookmarked;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
@@ -4,6 +4,8 @@ import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
 import devkor.com.teamcback.domain.common.BaseEntity;
 import devkor.com.teamcback.domain.common.LocationType;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,12 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Bookmark extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne
-    @JoinColumn(name = "category_id", nullable = false)
-    private Category category;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -30,9 +28,10 @@ public class Bookmark extends BaseEntity {
     @Column
     private String memo;
 
-    public Bookmark(CreateBookmarkReq req, Category category) {
-        //category_id, memo, placeType, 빌교편중1
-        this.category = category;
+    @OneToMany(mappedBy = "bookmark", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CategoryBookmark> categoryBookmarkList = new ArrayList<>();
+
+    public Bookmark(CreateBookmarkReq req) {
         this.memo = req.getMemo();
         this.locationType = req.getLocationType();
         this.locationId = req.getLocationId();

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Category.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Category.java
@@ -4,15 +4,20 @@ import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.ModifyCategoryReq;
 import devkor.com.teamcback.domain.common.BaseEntity;
 import devkor.com.teamcback.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Category extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -38,6 +43,9 @@ public class Category extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CategoryBookmark> categoryBookmarkList = new ArrayList<>();
 
     public Category(CreateCategoryReq req, User user) {
         this.category = req.getCategory();

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
@@ -1,0 +1,76 @@
+package devkor.com.teamcback.domain.bookmark.entity;
+
+import devkor.com.teamcback.domain.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "tb_category_bookmark")
+public class CategoryBookmark extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bookmark_id", nullable = false)
+    private Bookmark bookmark;
+
+    public void setCategoryAndBookmark(Category category, Bookmark bookmark) {
+        addCategoryBookmarkForCategory(category);
+        addCategoryBookmarkForBookmark(bookmark);
+        setCategory(category);
+        setBookmark(bookmark);
+    }
+
+    private void addCategoryBookmarkForCategory(Category category) {
+        if(!category.getCategoryBookmarkList().contains(this)) {
+            category.getCategoryBookmarkList().add(this);
+        }
+    }
+
+    private void addCategoryBookmarkForBookmark(Bookmark bookmark) {
+        if(!bookmark.getCategoryBookmarkList().contains(this)) {
+            bookmark.getCategoryBookmarkList().add(this);
+        }
+    }
+
+    private void setCategory(Category category) {
+        this.category = category;
+    }
+
+    private void setBookmark(Bookmark bookmark) {
+        this.bookmark = bookmark;
+    }
+
+    public void remove() {
+        removeFromCategory();
+        removeFromBookmark();
+    }
+
+    private void removeFromCategory() {
+        if(this.category != null) {
+            category.getCategoryBookmarkList().remove(this);
+        }
+    }
+
+    private void removeFromBookmark() {
+        if(this.bookmark != null) {
+            bookmark.getCategoryBookmarkList().remove(this);
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
@@ -9,8 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
-    Optional<Bookmark> findByCategoryAndLocationTypeAndLocationId(Category category, LocationType locationType, Long locationId);
-    Long countAllByCategory(Category category);
-    List<Bookmark> findAllByCategory(Category category);
-    Boolean existsByLocationTypeAndLocationIdAndCategoryIn(LocationType locationType, Long locationId, List<Category> category);
+    List<Bookmark> findAllByCategoryBookmarkList_CategoryId(Long categoryId);
+
+    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(Long locationId, LocationType locationType, Category category);
+
+    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(Long locationId, LocationType locationType,
+        List<Category> userCategoryList);
+
+    boolean existsByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(Long locationId, LocationType locationType,
+        List<Category> categories);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
@@ -1,0 +1,16 @@
+package devkor.com.teamcback.domain.bookmark.repository;
+
+import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
+import devkor.com.teamcback.domain.bookmark.entity.Category;
+import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
+import devkor.com.teamcback.domain.common.LocationType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryBookmarkRepository extends JpaRepository<CategoryBookmark, Long> {
+    boolean existsByCategoryAndBookmark(Category category, Bookmark bookmark);
+
+    Optional<CategoryBookmark> findByCategoryAndBookmark(Category category, Bookmark bookmark);
+
+    CategoryBookmark findByCategoryAndBookmarkLocationIdAndBookmarkLocationType(Category category, Long locationId, LocationType type);
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,185 @@
+package devkor.com.teamcback.domain.bookmark.service;
+
+import static devkor.com.teamcback.global.response.ResultCode.*;
+
+import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.dto.request.ModifyBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.dto.response.CreateBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.dto.response.DeleteBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.dto.response.ModifyBookmarkRes;
+import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
+import devkor.com.teamcback.domain.bookmark.entity.Category;
+import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
+import devkor.com.teamcback.domain.bookmark.entity.UserBookmarkLog;
+import devkor.com.teamcback.domain.bookmark.repository.BookmarkRepository;
+import devkor.com.teamcback.domain.bookmark.repository.CategoryBookmarkRepository;
+import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
+import devkor.com.teamcback.domain.bookmark.repository.UserBookmarkLogRepository;
+import devkor.com.teamcback.domain.building.repository.BuildingRepository;
+import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.place.repository.PlaceRepository;
+import devkor.com.teamcback.domain.user.entity.User;
+import devkor.com.teamcback.domain.user.repository.UserRepository;
+import devkor.com.teamcback.global.exception.GlobalException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final BuildingRepository buildingRepository;
+    private final PlaceRepository placeRepository;
+    private final UserBookmarkLogRepository userBookmarkLogRepository;
+    private final CategoryBookmarkRepository categoryBookmarkRepository;
+
+    /**
+     * 즐겨찾기 업데이트
+     */
+    @Transactional
+    public CreateBookmarkRes createBookmark(Long userId, CreateBookmarkReq req) {
+        User user = findUser(userId);
+
+        // placeType & Id로 장소 존재 여부 확인
+        checkPlaceExists(req.getLocationType(), req.getLocationId());
+
+        // 사용자의 카테고리 목록
+        List<Category> userCategoryList = categoryRepository.findAllByUser(user);
+
+        // 어떤 카테고리도 선택하지 않았을 때 해당 장소에 대한 사용자의 즐겨찾기 삭제
+        if(req.getCategoryIdList().isEmpty()) {
+            Bookmark bookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(req.getLocationId(), req.getLocationType(), userCategoryList);
+            if(bookmark != null) {
+                bookmarkRepository.delete(bookmark);
+            }
+        }
+
+        else {
+            // 자신의 카테고리가 아닌 id로 요청했을 경우
+            for (Long selectCategoryId : req.getCategoryIdList()) {
+                if (!userCategoryList.stream().map(Category::getId).toList()
+                    .contains(selectCategoryId)) {
+                    throw new GlobalException(UNAUTHORIZED);
+                }
+            }
+
+            Bookmark bookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(req.getLocationId(), req.getLocationType(), userCategoryList);
+            if(bookmark == null) {
+                bookmark = bookmarkRepository.save(new Bookmark(req));
+            }
+
+
+            for (Category category : userCategoryList) {
+                boolean isSelected = req.getCategoryIdList().contains(category.getId());
+                Bookmark existedBookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(
+                    req.getLocationId(), req.getLocationType(), category);
+
+                if (existedBookmark != null && !isSelected) { // 북마크 o -> 선택 x
+                    // 해당 카테고리 내의 즐겨찾기 삭제
+                    CategoryBookmark categoryBookmark = categoryBookmarkRepository.findByCategoryAndBookmark(
+                            category, existedBookmark)
+                        .orElseThrow(() -> new GlobalException(NOT_FOUND_IN_CATEGORY));
+                    deleteCategoryBookmark(categoryBookmark);
+                } else if (existedBookmark == null && isSelected) { // 북마크 x -> 선택 o
+                    // 해당 카테고리의 북마크 생성
+                    CategoryBookmark categoryBookmark = new CategoryBookmark();
+                    categoryBookmark.setCategoryAndBookmark(category, bookmark);
+                    categoryBookmarkRepository.save(categoryBookmark);
+                }
+
+            }
+
+            // 첫 저장이면 Score 증가
+            addScoreIfNewBookmarkLog(user, req);
+        }
+
+        return new CreateBookmarkRes();
+    }
+
+    /**
+     * 즐겨찾기 삭제 - 해당 장소와 관련된 모든 즐겨찾기 삭제
+     */
+    @Transactional
+    public DeleteBookmarkRes deleteBookmark(Long userId, Long bookmarkId) {
+        User user = findUser(userId);
+
+        Bookmark bookmark = findBookmark(bookmarkId);
+
+        // 카테고리 소유자인지 확인
+        checkAuthority(user, bookmark);
+
+        bookmarkRepository.delete(bookmark);
+
+        return new DeleteBookmarkRes();
+    }
+
+    /**
+     * 즐겨찾기 수정 (memo 수정만 가능)
+     */
+    @Transactional
+    public ModifyBookmarkRes modifyBookmark(Long userId, Long bookmarkId, ModifyBookmarkReq req) {
+        User user = findUser(userId);
+        Bookmark bookmark = findBookmark(bookmarkId);
+
+        // 카테고리 소유자인지 확인
+        checkAuthority(user, bookmark);
+
+        bookmark.update(req.getMemo());
+
+        return new ModifyBookmarkRes();
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new GlobalException(NOT_FOUND_USER));
+    }
+
+    private Bookmark findBookmark(Long bookmarkId) {
+        return bookmarkRepository.findById(bookmarkId).orElseThrow(() -> new GlobalException(NOT_FOUND_BOOKMARK));
+    }
+
+    private void checkAuthority(User user, Bookmark bookmark) {
+        if(bookmark.getCategoryBookmarkList().stream().noneMatch(categoryBookmark -> categoryBookmark.getCategory().getUser().getUserId().equals(user.getUserId()))) {
+            throw new GlobalException(UNAUTHORIZED);
+        }
+    }
+
+    private void checkPlaceDuplication(Category category, LocationType locationType, Long locationId) {
+        CategoryBookmark categoryBookmark = categoryBookmarkRepository.findByCategoryAndBookmarkLocationIdAndBookmarkLocationType(category, locationId, locationType);
+
+        // 같은 카테고리에 동일 북마크가 존재하는 경우
+        if (categoryBookmark != null) {
+            throw new GlobalException(DUPLICATED_BOOKMARK);
+        }
+    }
+
+    private void checkPlaceExists(LocationType locationType, Long locationId) {
+        if (LocationType.BUILDING.equals(locationType) && !buildingRepository.existsById(locationId)) {
+            throw new GlobalException(NOT_FOUND_BUILDING);
+        } else if (LocationType.PLACE.equals(locationType) && !placeRepository.existsById(locationId)) {
+            throw new GlobalException(NOT_FOUND_PLACE);
+        }
+    }
+
+    private void addScoreIfNewBookmarkLog(User user, CreateBookmarkReq req) {
+        // log에 없으면 Score 1점 증가
+        if(!userBookmarkLogRepository.existsByUserAndLocationIdAndLocationType(user, req.getLocationId(), req.getLocationType())) {
+            user.updateScore(user.getScore() + 1);
+            userBookmarkLogRepository.save(new UserBookmarkLog(req.getLocationId(), req.getLocationType(), user));
+        }
+    }
+
+    private void deleteCategoryBookmark(CategoryBookmark categoryBookmark) {
+        Bookmark bookmark = categoryBookmark.getBookmark();
+        categoryBookmark.remove();
+        categoryBookmarkRepository.delete(categoryBookmark);
+        if(bookmark.getCategoryBookmarkList().isEmpty()) {
+            bookmarkRepository.delete(bookmark);
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
@@ -1,28 +1,22 @@
 package devkor.com.teamcback.domain.bookmark.service;
 
-import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
-import devkor.com.teamcback.domain.bookmark.dto.request.ModifyBookmarkReq;
 import devkor.com.teamcback.domain.bookmark.dto.request.ModifyCategoryReq;
 import devkor.com.teamcback.domain.bookmark.dto.response.*;
 import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
-import devkor.com.teamcback.domain.bookmark.entity.UserBookmarkLog;
+import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
 import devkor.com.teamcback.domain.bookmark.repository.BookmarkRepository;
+import devkor.com.teamcback.domain.bookmark.repository.CategoryBookmarkRepository;
 import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
-import devkor.com.teamcback.domain.bookmark.repository.UserBookmarkLogRepository;
-import devkor.com.teamcback.domain.building.repository.BuildingRepository;
-import devkor.com.teamcback.domain.common.LocationType;
-import devkor.com.teamcback.domain.place.repository.PlaceRepository;
 import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
+import java.awt.print.Book;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 import static devkor.com.teamcback.global.response.ResultCode.*;
 
@@ -33,9 +27,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
     private final BookmarkRepository bookmarkRepository;
-    private final BuildingRepository buildingRepository;
-    private final PlaceRepository placeRepository;
-    private final UserBookmarkLogRepository userBookmarkLogRepository;
+    private final CategoryBookmarkRepository categoryBookmarkRepository;
 
     /**
      * 카테고리 생성
@@ -102,7 +94,8 @@ public class CategoryService {
     public GetCategoryListRes getAllCategories(Long userId) {
         User user = findUser(userId);
 
-        return new GetCategoryListRes(categoryRepository.findAllByUser(user).stream().map(category -> new GetCategoryRes(category, bookmarkRepository.countAllByCategory(category))).toList());
+        return new GetCategoryListRes(categoryRepository.findAllByUser(user)
+            .stream().map(category -> new GetCategoryRes(category, category.getCategoryBookmarkList().size())).toList());
     }
 
     /**
@@ -116,37 +109,26 @@ public class CategoryService {
         // 카테고리 소유자인지 확인
         checkAuthority(user, category.getUser());
 
-        return new GetBookmarkListRes(bookmarkRepository.findAllByCategory(category).stream().map(GetBookmarkRes::new).toList());
+        return new GetBookmarkListRes(bookmarkRepository.findAllByCategoryBookmarkList_CategoryId(categoryId).stream().map(GetBookmarkRes::new).toList());
     }
 
     /**
-     * 즐겨찾기 생성
+     * 카테고리 내 즐겨찾기 상세 조회
      */
-    @Transactional
-    public CreateBookmarkRes createBookmark(Long userId, Long categoryId, CreateBookmarkReq req) {
+    @Transactional(readOnly = true)
+    public GetBookmarkRes getBookmark(Long userId, Long categoryId, Long bookmarkId) {
         User user = findUser(userId);
         Category category = findCategory(categoryId);
+        Bookmark bookmark = findBookmark(category, bookmarkId);
 
-        //카테고리 소유자 확인
+        // 카테고리 소유자인지 확인
         checkAuthority(user, category.getUser());
 
-        //placeType & Id로 장소 존재 여부 확인
-        checkPlaceExists(req.getLocationType(), req.getLocationId());
-
-        //장소 중복 확인하기
-        //해당 카테고리안에 placeType, placeId가 모두 동일한 것이 있으면 중복
-        checkPlaceDuplication(category, req.getLocationType(), req.getLocationId());
-
-        // 첫 저장이면 Score 증가
-        addScoreIfNewBookmarkLog(user, req);
-
-        //즐겨찾기 생성
-        Bookmark bookmark = bookmarkRepository.save(new Bookmark(req, category));
-        return new CreateBookmarkRes(bookmark);
+        return new GetBookmarkRes(bookmark);
     }
 
     /**
-     * 즐겨찾기 삭제
+     * 카테고리 내 즐겨찾기 삭제
      */
     @Transactional
     public DeleteBookmarkRes deleteBookmark(Long userId, Long categoryId, Long bookmarkId) {
@@ -157,43 +139,11 @@ public class CategoryService {
         Bookmark bookmark = findBookmark(category, bookmarkId);
 
         // 카테고리 소유자인지 확인
-        checkAuthority(user, bookmark.getCategory().getUser());
+        checkAuthority(user, category.getUser());
 
-        bookmarkRepository.delete(bookmark);
-
+        CategoryBookmark categoryBookmark = findCategoryBookmark(category, bookmark);
+        deleteCategoryBookmark(categoryBookmark);
         return new DeleteBookmarkRes();
-    }
-
-    /**
-     * 즐겨찾기 수정 (memo 수정만 가능)
-     */
-    @Transactional
-    public ModifyBookmarkRes modifyBookmark(Long userId, Long categoryId, Long bookmarkId, ModifyBookmarkReq req) {
-        User user = findUser(userId);
-        Category category = findCategory(categoryId);
-        Bookmark bookmark = findBookmark(category, bookmarkId);
-
-        // 카테고리 소유자인지 확인
-        checkAuthority(user, bookmark.getCategory().getUser());
-
-        bookmark.update(req.getMemo());
-
-        return new ModifyBookmarkRes();
-    }
-
-    /**
-     * 즐겨찾기 조회
-     */
-    @Transactional(readOnly = true)
-    public GetBookmarkRes getBookmark(Long userId, Long categoryId, Long bookmarkId) {
-        User user = findUser(userId);
-        Category category = findCategory(categoryId);
-        Bookmark bookmark = findBookmark(category, bookmarkId);
-
-        // 카테고리 소유자인지 확인
-        checkAuthority(user, bookmark.getCategory().getUser());
-
-        return new GetBookmarkRes(bookmark);
     }
 
     private User findUser(Long userId) {
@@ -213,34 +163,23 @@ public class CategoryService {
     private Bookmark findBookmark(Category category, Long bookmarkId) {
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(() -> new GlobalException(NOT_FOUND_BOOKMARK));
 
-        if(category.equals(bookmark.getCategory())) {
-            return bookmark;
+        if(!categoryBookmarkRepository.existsByCategoryAndBookmark(category, bookmark)) {
+            throw new GlobalException(NOT_FOUND_IN_CATEGORY);
         }
-        throw new GlobalException(NOT_FOUND_IN_CATEGORY);
+
+        return bookmark;
     }
 
-    private void checkPlaceDuplication(Category category, LocationType locationType, Long placeId) {
-        Optional<Bookmark> optionalBookmark = bookmarkRepository.findByCategoryAndLocationTypeAndLocationId(category, locationType, placeId);
-
-        // 같은 카테고리에 동일 북마크가 존재하는 경우
-        if (optionalBookmark.isPresent()) {
-            throw new GlobalException(DUPLICATED_BOOKMARK);
-        }
+    private CategoryBookmark findCategoryBookmark(Category category, Bookmark bookmark) {
+        return categoryBookmarkRepository.findByCategoryAndBookmark(category, bookmark).orElseThrow(() -> new GlobalException(NOT_FOUND_IN_CATEGORY));
     }
 
-    public void checkPlaceExists(LocationType locationType, Long placeId) {
-        if (LocationType.BUILDING.equals(locationType) && !buildingRepository.existsById(placeId)) {
-            throw new GlobalException(NOT_FOUND_BUILDING);
-        } else if (LocationType.PLACE.equals(locationType) && !placeRepository.existsById(placeId)) {
-            throw new GlobalException(NOT_FOUND_PLACE);
-        }
-    }
-
-    private void addScoreIfNewBookmarkLog(User user, CreateBookmarkReq req) {
-        // log에 없으면 Score 1점 증가
-        if(!userBookmarkLogRepository.existsByUserAndLocationIdAndLocationType(user, req.getLocationId(), req.getLocationType())) {
-            user.updateScore(user.getScore() + 1);
-            userBookmarkLogRepository.save(new UserBookmarkLog(req.getLocationId(), req.getLocationType(), user));
+    private void deleteCategoryBookmark(CategoryBookmark categoryBookmark) {
+        Bookmark bookmark = categoryBookmark.getBookmark();
+        categoryBookmark.remove();
+        categoryBookmarkRepository.delete(categoryBookmark);
+        if(bookmark.getCategoryBookmarkList().isEmpty()) {
+            bookmarkRepository.delete(bookmark);
         }
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -123,7 +123,7 @@ public class SearchController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    public CommonResponse<SearchRoomRes> searchPlaceByBuildingFloor(
+    public CommonResponse<SearchFloorInfoRes> searchPlaceByBuildingFloor(
         @Parameter(name = "buildingId", description = "건물 id", example = "1", required = true)
         @PathVariable Long buildingId,
         @Parameter(name = "floor", description = "건물 층", example = "1", required = true)

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFloorInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFloorInfoRes.java
@@ -8,7 +8,7 @@ public class SearchFloorInfoRes {
     private List<SearchRoomDetailRes> roomList;
     private List<SearchNodeRes> nodeList;
 
-    public SearchFloorInfoRes(List<SearchRoomDetailRes> roomList) {
+    public SearchFloorInfoRes(List<SearchRoomDetailRes> roomList, List<SearchNodeRes> nodeList) {
         this.roomList = roomList;
         this.nodeList = nodeList;
     }

--- a/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFloorInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/dto/response/SearchFloorInfoRes.java
@@ -4,10 +4,10 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class SearchRoomRes {
+public class SearchFloorInfoRes {
     private List<SearchRoomDetailRes> roomList;
 
-    public SearchRoomRes(List<SearchRoomDetailRes> roomList) {
+    public SearchFloorInfoRes(List<SearchRoomDetailRes> roomList) {
         this.roomList = roomList;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -188,13 +188,13 @@ public class SearchService {
      * 건물 특정 층에 있는 장소 검색
      */
     @Transactional(readOnly = true)
-    public SearchRoomRes searchPlaceByBuildingFloor(Long buildingId, int floor) {
+    public SearchFloorInfoRes searchPlaceByBuildingFloor(Long buildingId, int floor) {
          Building building = findBuilding(buildingId);
          List<Place> placeList = placeRepository.findAllByBuildingAndFloor(building, floor);
 
          List<SearchRoomDetailRes> roomDetailRes = new ArrayList<>(
              placeList.stream().map(SearchRoomDetailRes::new).toList());
-         return new SearchRoomRes(roomDetailRes);
+         return new SearchFloorInfoRes(roomDetailRes);
     }
 
     /**
@@ -257,7 +257,7 @@ public class SearchService {
             User user = findUser(userId);
             // 해당 유저의 북마크에 빌딩 있는지 확인 (유저의 카테고리 리스트 가져와서, 해당 안에 존재하는지 확인)
             List<Category> categories = categoryRepository.findAllByUser(user);
-            if(bookmarkRepository.existsByLocationTypeAndLocationIdAndCategoryIn(LocationType.BUILDING, buildingId, categories)) {
+            if(bookmarkRepository.existsByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(buildingId, LocationType.BUILDING, categories)) {
                 bookmarked = true;
             }
         }
@@ -282,7 +282,7 @@ public class SearchService {
         }
 
         Place place = findPlace(placeId);
-        if(bookmarkRepository.existsByLocationTypeAndLocationIdAndCategoryIn(LocationType.PLACE, place.getId(), categories)) {
+        if(bookmarkRepository.existsByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(place.getId(), LocationType.PLACE, categories)) {
             bookmarked = true;
         }
         return new SearchPlaceDetailRes(place, bookmarked, placeImageRepository.findAllByPlace(place).stream().map(SearchPlaceImageRes::new).toList());


### PR DESCRIPTION
## 개요
카테고리 및 즐겨찾기 수정

## 작업사항
- 카테고리, 즐겨찾기 다대다 연관관계로 수정
- 카테고리, 즐겨찾기의 컨트롤러, 서비스 분리
- 즐겨찾기 생성 및 수정 시 카테고리를 리스트로 받도록 수정
- 카테고리 조회 시 장소 정보를 함께 보내면 해당 장소의 즐겨찾기 id, 해당 즐겨찾기의 카테고리 포함 여부 등의 정보도 반환하도록 추가

## 관련 이슈
- 즐겨찾기 업데이트 시 카테고리를 선택하지 않으면 해당 즐겨찾기가 삭제됩니다.
- 즐겨찾기에서 장소 id와 type이 같은 경우 기존의 즐겨찾기를 사용합니다.
- 카테고리 내에서 즐겨찾기를 삭제하였는데 더 이상 그 즐겨찾기에 해당하는 카테고리가 없는 경우 즐겨찾기가 삭제됩니다.
