### PR TITLE
경로탐색 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
@@ -1,12 +1,15 @@
 package devkor.com.teamcback.domain.building.repository;
 
 import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.routes.entity.Node;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
     Building findBuildingById(long id);
+
+    Building findBuildingByNode(Node node);
 
     List<Building> findAllByIdNotIn(List<Long> buildingIdList);
 }

--- a/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
@@ -80,8 +80,7 @@ public class RouteController {
             endLocation.add(endId.doubleValue());
         }
         List<GetRouteRes> returnList = new ArrayList<>();
-        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, null));
-        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, NodeType.STAIR));
+        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, NodeType.SHUTTLE));
         return CommonResponse.success(returnList);
     }
 }


### PR DESCRIPTION
## 개요
경로탐색 수정

## 작업사항
- 일단 여러 경로가 아닌 하나의 경로를 제공하는 것이 목적이기에, 경로가 empty이면 아예 globalexception 6001을 던지도록 변경
- 시작, 끝경로가 건물이라면 첫 노드, 끝 노드 제거(TODO: 리팩토링 가능, 우선순위는 낮기에 나중에 진행할 사항)
- 경로 끊기 및 안내문 제공 완료. 이제 외부에서 건물로 들어갈 때, 도착지점이 건물일 때 들어가기 전/도착지점에서 한번 끊어 주어 화면 이동이 가능하게 함.
- 임시로 RouteController에서 NodeType.SHUTTLE을 ban하게 하여 셔틀버스 관련 경로는 전부 차단


