### PR TITLE
Fix: API 권한 제한

### DIFF
--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -64,13 +64,9 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
             authorizeHttpRequests
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                .requestMatchers("/api/search/**").permitAll()
                 .requestMatchers("/api/koyeon/**").permitAll() // 고연전 이후 삭제 필요
-                .requestMatchers("/api/routes/**").permitAll()
                 .requestMatchers("/api/users/login").permitAll()
-                .requestMatchers("/api/suggestions/**").permitAll()
-                .requestMatchers("/api/admin/**").permitAll() // TODO: 이후 아래로 변경
-//                .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용
+                .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용
                 .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/swagger-ui.html").permitAll()
                 .requestMatchers("/api-docs/**").permitAll()


### PR DESCRIPTION
## 개요
Fix: API 권한 제한

## 작업사항
- 고연전, 로그인 관련 API는 허용하고 나머지는 로그인이 필요하도록 수정
- 관리자 관련 API는 관리자만 가능

## 관련 이슈
- 노드 관리 툴 수정 예정
