### PR TITLE
Feat: 가까운 거리 예외처리 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
@@ -58,7 +58,7 @@ public class RouteController {
         @RequestParam(required = false) Double startLong,
         @Parameter(name = "endType", description = "도착 장소의 LocationType", example = "BUILDING", required = true)
         @RequestParam LocationType endType,
-        @Parameter(name = "endId", description = "endType이 COORD가 아닐 경우 해당 시설의 ID", required = true)
+        @Parameter(name = "endId", description = "endType이 COORD가 아닐 경우 해당 시설의 ID")
         @RequestParam(required = false) Long endId,
         @Parameter(name = "endLat", description = "endType이 COORD일 경우 해당 장소의 위도")
         @RequestParam(required = false) Double endLat,

--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -63,6 +63,10 @@ public class RouteService {
             }
         }
 
+        if (startNode.getBuilding().getId() == 0L && endNode.getBuilding().getId() == 0L){
+            if (getEuclidDistance(startNode.getLatitude(), startNode.getLongitude(), endNode.getLatitude(), endNode.getLongitude()) < 0.0001) throw new GlobalException(COORDINATES_TOO_NEAR);
+        }
+
         List<Building> buildingList = getBuildingsForRoute(startNode, endNode);
         GetGraphRes graphRes = getGraph(buildingList, startNode, endNode, barrierFree);
         DijkstraRes route = dijkstra(graphRes.getGraphNode(), graphRes.getGraphEdge(), startNode, endNode);

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -44,6 +44,7 @@ public enum ResultCode {
     NOT_PROVIDED_ROUTE(HttpStatus.BAD_REQUEST, 6002, "해당 경로는 제공되지 않습니다."),
     COORDINATES_TOO_FAR(HttpStatus.BAD_REQUEST, 6003, "찾고자 하는 경로가 캠퍼스에서 너무 멉니다."),
     NOT_OPERATING(HttpStatus.NOT_FOUND, 6004, "현재 운영중이 아닌 시설입니다."),
+    COORDINATES_TOO_NEAR(HttpStatus.BAD_REQUEST, 6005, "찾고자 하는 두 지점이 서로 너무 가깝습니다."),
 
     // 즐겨찾기 7000번대
     INCORRECT_COLOR(HttpStatus.BAD_REQUEST, 7000, "정해진 색상 내에서 선택해주세요."),


### PR DESCRIPTION
## 개요
가까운 거리 예외처리 추가

## 작업사항
- 외부->외부 경로탐색의 경우 시작노드와 끝 노드가 너무 가까우면 예외사항 리턴
- api/routes가 endId를 반드시 필요로 하는 버그 수정

## 관련 이슈
- 
