### PR TITLE
Feat: 태그검색 API

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/koyeon/controller/KoyeonController.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/controller/KoyeonController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,8 +48,11 @@ public class KoyeonController {
         @ApiResponse(responseCode = "404", description = "Not Found",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    public CommonResponse<SearchFreePubListRes> searchFreePubList() {
-        return CommonResponse.success(koyeonService.searchFreePubList());
+    public CommonResponse<SearchFreePubListRes> searchFreePubList(
+        @Parameter(name = "tagId", description = "태그 id", example = "1")
+        @RequestParam(required = false) Long tagId
+    ) {
+        return CommonResponse.success(koyeonService.searchFreePubList(tagId));
     }
 
     /***

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
@@ -2,7 +2,10 @@ package devkor.com.teamcback.domain.koyeon.dto.response;
 
 import devkor.com.teamcback.domain.koyeon.entity.FreePub;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Schema(description = "주점 정보")
 @Getter
@@ -15,11 +18,21 @@ public class SearchFreePubRes {
     private Double longitude;
     @Schema(description = "주점 위도", example = "37.5844829")
     private Double latitude;
+    @Schema(description = "태그에 해당하는 음식 리스트", example = "[\"떡볶이\"]")
+    private List<String> filteredMenus = new ArrayList<>();
 
     public SearchFreePubRes(FreePub pub) {
         this.id = pub.getId();
         this.name = pub.getName();
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
+    }
+
+    public SearchFreePubRes(FreePub pub, List<String> filteredMenus) {
+        this.id = pub.getId();
+        this.name = pub.getName();
+        this.latitude = pub.getLatitude();
+        this.longitude = pub.getLongitude();
+        this.filteredMenus = filteredMenus;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
@@ -14,6 +14,10 @@ public class SearchFreePubRes {
     private Long id;
     @Schema(description = "주점 이름", example = "맛닭꼬")
     private String name;
+    @Schema(description = "후원 단체", example = "79학번 동기회")
+    private String sponsor;
+    @Schema(description = "운영 시간", example = "19:00-22:00")
+    private String operatingTime;
     @Schema(description = "주점 경도", example = "127.0274309")
     private Double longitude;
     @Schema(description = "주점 위도", example = "37.5844829")
@@ -24,6 +28,8 @@ public class SearchFreePubRes {
     public SearchFreePubRes(FreePub pub) {
         this.id = pub.getId();
         this.name = pub.getName();
+        this.sponsor = pub.getSponsor();
+        this.operatingTime = pub.getOperatingTime();
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
     }
@@ -31,6 +37,8 @@ public class SearchFreePubRes {
     public SearchFreePubRes(FreePub pub, List<String> filteredMenus) {
         this.id = pub.getId();
         this.name = pub.getName();
+        this.sponsor = pub.getSponsor();
+        this.operatingTime = pub.getOperatingTime();
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
         this.filteredMenus = filteredMenus;

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/repository/MenuRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/repository/MenuRepository.java
@@ -1,8 +1,11 @@
 package devkor.com.teamcback.domain.koyeon.repository;
 
+import devkor.com.teamcback.domain.koyeon.entity.FreePub;
 import devkor.com.teamcback.domain.koyeon.entity.Menu;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
+    List<Menu> findByFreePub(FreePub pub);
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/repository/TagMenuRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/repository/TagMenuRepository.java
@@ -1,8 +1,12 @@
 package devkor.com.teamcback.domain.koyeon.repository;
 
+import devkor.com.teamcback.domain.koyeon.entity.FoodTag;
+import devkor.com.teamcback.domain.koyeon.entity.Menu;
 import devkor.com.teamcback.domain.koyeon.entity.TagMenu;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagMenuRepository extends JpaRepository<TagMenu, Long> {
 
+    List<TagMenu> findByFoodTag(FoodTag tag);
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/service/KoyeonService.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/service/KoyeonService.java
@@ -3,10 +3,19 @@ package devkor.com.teamcback.domain.koyeon.service;
 import devkor.com.teamcback.domain.koyeon.dto.response.SearchFreePubInfoRes;
 import devkor.com.teamcback.domain.koyeon.dto.response.SearchFreePubListRes;
 import devkor.com.teamcback.domain.koyeon.dto.response.SearchFreePubRes;
+import devkor.com.teamcback.domain.koyeon.entity.FoodTag;
+import devkor.com.teamcback.domain.koyeon.entity.FreePub;
 import devkor.com.teamcback.domain.koyeon.entity.Koyeon;
+import devkor.com.teamcback.domain.koyeon.entity.Menu;
+import devkor.com.teamcback.domain.koyeon.entity.TagMenu;
+import devkor.com.teamcback.domain.koyeon.repository.FoodTagRepository;
 import devkor.com.teamcback.domain.koyeon.repository.FreePubRepository;
 import devkor.com.teamcback.domain.koyeon.repository.KoyeonRepository;
+import devkor.com.teamcback.domain.koyeon.repository.MenuRepository;
+import devkor.com.teamcback.domain.koyeon.repository.TagMenuRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_KOYEON;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_PUB;
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_TAG;
 
 @Slf4j
 @Service
@@ -21,6 +31,9 @@ import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_PUB;
 public class KoyeonService {
     private final KoyeonRepository koyeonRepository;
     private final FreePubRepository freePubRepository;
+    private final FoodTagRepository foodTagRepository;
+    private final MenuRepository menuRepository;
+    private final TagMenuRepository tagMenuRepository;
 
     /**
      * 고연전 여부 확인
@@ -34,7 +47,25 @@ public class KoyeonService {
      * 무료 주점 List 반환
      */
     @Transactional(readOnly = true)
-    public SearchFreePubListRes searchFreePubList() {
+    public SearchFreePubListRes searchFreePubList(Long tagId) {
+        if(tagId != null) {
+            FoodTag tag = foodTagRepository.findById(tagId).orElseThrow(() -> new GlobalException(NOT_FOUND_TAG));
+
+            // 태그에 해당하는 음식 리스트
+            List<Menu> menuList = tagMenuRepository.findByFoodTag(tag).stream().map(TagMenu::getMenu).toList();
+
+            // 음식을 가진 음식점 리스트
+            List<FreePub> pubList = menuList.stream().map(Menu::getFreePub).distinct().toList();
+
+            List<SearchFreePubRes> pubResList = new ArrayList<>();
+            for (FreePub pub : pubList) {
+                pubResList.add(new SearchFreePubRes(pub, menuRepository.findByFreePub(pub).stream().filter(
+                    menuList::contains).map(Menu::getName).toList()));
+            }
+
+            return new SearchFreePubListRes(pubResList);
+        }
+
         return new SearchFreePubListRes(freePubRepository.findAll()
             .stream()
             .map(SearchFreePubRes::new)

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -60,7 +60,10 @@ public enum ResultCode {
     NOT_FOUND_PUB(HttpStatus.NOT_FOUND, 9001, "주점 정보를 찾을 수 없습니다."),
 
     // 운영 시간 10000번대
-    OPER_CONDITION_HAS_NO_OPER_TIME(HttpStatus.NOT_FOUND, 10000, "운영 조건이 운영 시간을 가지고 있지 않습니다.")
+    OPER_CONDITION_HAS_NO_OPER_TIME(HttpStatus.NOT_FOUND, 10000, "운영 조건이 운영 시간을 가지고 있지 않습니다."),
+
+    // 고연전 11000번대
+    NOT_FOUND_TAG(HttpStatus.NOT_FOUND, 11000, "음식 태그를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 개요
태그검색 API 추가

## 작업사항
- 파라미터가 없으면 전체 주점 조회
- 파라미터(태그 ID)가 있으면 해당 태그를 가진 메뉴의 가게와 메뉴 반환

## 관련 이슈
- 
