### PR TITLE
SecurityConfig api 권한 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/GlobalPubSearchRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/GlobalPubSearchRes.java
@@ -15,8 +15,10 @@ public class GlobalPubSearchRes {
     private String name;
     @Schema(description = "후원처", example = "승명호 교우회장님")
     private String sponsor;
-    @Schema(description = "", example = "서울특별시 성북구 고려대로24길 27")
+    @Schema(description = "주소", example = "서울특별시 성북구 고려대로24길 27")
     private String address;
+    @Schema(description = "노드 ID", example = "1")
+    private Long nodeId = null;
 
     @Override
     public boolean equals(Object o) {
@@ -35,6 +37,7 @@ public class GlobalPubSearchRes {
         this.name = pub.getName();
         this.sponsor = pub.getSponsor();
         this.address = pub.getAddress();
+        if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
     }
 
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubInfoRes.java
@@ -24,6 +24,8 @@ public class SearchFreePubInfoRes {
     private String address;
     @Schema(description = "운영시간", example = "19:00-22:00")
     private String operatingTime;
+    @Schema(description = "노드 ID", example = "1")
+    private Long nodeId = null;
     @Schema(description = "메뉴List", example = "술, 밥, 치킨")
     private List<String> menus;
 
@@ -36,5 +38,6 @@ public class SearchFreePubInfoRes {
         this.address = pub.getAddress();
         this.operatingTime = pub.getOperatingTime();
         this.menus = menus.stream().map(Menu::getName).toList();
+        if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
@@ -22,6 +22,8 @@ public class SearchFreePubRes {
     private Double longitude;
     @Schema(description = "주점 위도", example = "37.5844829")
     private Double latitude;
+    @Schema(description = "노드 ID", example = "1")
+    private Long nodeId = null;
     @Schema(description = "태그에 해당하는 음식 리스트", example = "[\"떡볶이\"]")
     private List<String> filteredMenus = new ArrayList<>();
 
@@ -32,6 +34,7 @@ public class SearchFreePubRes {
         this.operatingTime = pub.getOperatingTime();
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
+        if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
     }
 
     public SearchFreePubRes(FreePub pub, List<String> filteredMenus) {
@@ -41,6 +44,7 @@ public class SearchFreePubRes {
         this.operatingTime = pub.getOperatingTime();
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
+        if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
         this.filteredMenus = filteredMenus;
     }
 }

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -64,6 +65,8 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
             authorizeHttpRequests
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/routes/**").permitAll()
                 .requestMatchers("/api/koyeon/**").permitAll() // 고연전 이후 삭제 필요
                 .requestMatchers("/api/users/login").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용


### PR DESCRIPTION
## 개요
편의성과 추후 주점 길찾기를 위해 길찾기와 검색 API의 경우 GET 요청은 허용하도록 SecurityConfig를 수정했습니다.

## 작업사항
- SecurityConfig 수정: '/api/search/\*\*', '/api/routes/\*\*' 에 대하여 GET 요청 허용
- dto에 nodeId 추가

## 관련 이슈
- 
