### PR TITLE
Feat: 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostRemove;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/CategoryBookmark.java
@@ -28,7 +28,7 @@ public class CategoryBookmark extends BaseEntity {
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bookmark_id", nullable = false)
+    @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
 
     public void setCategoryAndBookmark(Category category, Bookmark bookmark) {

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
@@ -4,6 +4,8 @@ import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
 import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
 import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
@@ -22,4 +22,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
         @Param("locationType") LocationType locationType,
         @Param("locationId") Long locationId
     );
+
+    List<Category> findByUser(User user);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
@@ -23,5 +23,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
         @Param("locationId") Long locationId
     );
 
-    List<Category> findByUser(User user);
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.categoryBookmarkList WHERE c.user = :user")
+    List<Category> findByUser(@Param("user") User user);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/UserBookmarkLogRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/UserBookmarkLogRepository.java
@@ -3,8 +3,11 @@ package devkor.com.teamcback.domain.bookmark.repository;
 import devkor.com.teamcback.domain.bookmark.entity.UserBookmarkLog;
 import devkor.com.teamcback.domain.common.LocationType;
 import devkor.com.teamcback.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserBookmarkLogRepository extends JpaRepository<UserBookmarkLog, Long> {
     boolean existsByUserAndLocationIdAndLocationType(User user, Long locationId, LocationType locationType);
+
+    List<UserBookmarkLog> findByUser(User user);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
@@ -53,6 +53,14 @@ public class CategoryService {
         // 카테고리 소유자인지 확인
         checkAuthority(user, category.getUser());
 
+        // 각 북마크가 다른 카테고리와 연결되어 있지 않은지 확인 후 삭제
+        category.getCategoryBookmarkList().forEach(categoryBookmark -> {
+            Bookmark bookmark = categoryBookmark.getBookmark();
+            if (bookmark.getCategoryBookmarkList().size() == 1) {
+                bookmarkRepository.delete(bookmark);
+            }
+        });
+
         categoryRepository.delete(category);
 
         return new DeleteCategoryRes();

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/entity/Suggestion.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/entity/Suggestion.java
@@ -7,6 +7,7 @@ import devkor.com.teamcback.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -30,6 +31,7 @@ public class Suggestion extends BaseEntity {
     @Column(nullable = false)
     private boolean isSolved = false;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "userId")
     private User user;
@@ -44,4 +46,5 @@ public class Suggestion extends BaseEntity {
     public void updateIsSolved(boolean solved) {
         this.isSolved = solved;
     }
+
 }

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/repository/SuggestionRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/repository/SuggestionRepository.java
@@ -2,6 +2,8 @@ package devkor.com.teamcback.domain.suggestion.repository;
 
 import devkor.com.teamcback.domain.suggestion.entity.Suggestion;
 import devkor.com.teamcback.domain.suggestion.entity.SuggestionType;
+import devkor.com.teamcback.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +14,6 @@ public interface SuggestionRepository extends JpaRepository<Suggestion, Long> {
     Page<Suggestion> findBySuggestionType(Pageable pageable, SuggestionType type);
 
     Page<Suggestion> findBySuggestionTypeAndIsSolved(Pageable pageable, SuggestionType type, Boolean isSolved);
+
+    List<Suggestion> findByUser(User user);
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.user.controller;
 
 import devkor.com.teamcback.domain.user.dto.request.LoginUserReq;
+import devkor.com.teamcback.domain.user.dto.response.DeleteUserRes;
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
 import devkor.com.teamcback.domain.user.dto.response.LoginUserRes;
 import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
@@ -73,5 +74,22 @@ public class UserController {
         @Parameter(description = "사용자명", required = true)
         @RequestParam String username) {
         return CommonResponse.success(userService.modifyUsername(userDetail.getUser().getUserId(), username));
+    }
+
+    /**
+     * 사용자 회원 탈퇴
+     * @param userDetail 사용자 정보
+     */
+    @Operation(summary = "사용자 회원 탈퇴", description = "사용자 회원 탈퇴")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+        @ApiResponse(responseCode = "404", description = "Not Found",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @DeleteMapping
+    public CommonResponse<DeleteUserRes> deleteUser(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal UserDetailsImpl userDetail) {
+        return CommonResponse.success(userService.deleteUser(userDetail.getUser().getUserId()));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/DeleteUserRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/DeleteUserRes.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.user.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 회원 탈퇴")
+@JsonIgnoreProperties
+public class DeleteUserRes {
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -122,8 +122,14 @@ public class UserService {
             categoryRepository.delete(category);
         }
 
+        // 건의 익명 처리
+        List<Suggestion> suggestions = suggestionRepository.findByUser(user);
+        for(Suggestion suggestion : suggestions) {
+            suggestion.setUser(null);
+        }
+
         userBookmarkLogRepository.deleteAll(userBookmarkLogRepository.findByUser(user));
-        suggestionRepository.deleteAll(suggestionRepository.findByUser(user));
+//        suggestionRepository.deleteAll(suggestionRepository.findByUser(user));
         userRepository.delete(user);
 
         return new DeleteUserRes();

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -1,9 +1,18 @@
 package devkor.com.teamcback.domain.user.service;
 
+import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
+import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Color;
+import devkor.com.teamcback.domain.bookmark.entity.UserBookmarkLog;
+import devkor.com.teamcback.domain.bookmark.repository.BookmarkRepository;
+import devkor.com.teamcback.domain.bookmark.repository.CategoryBookmarkRepository;
 import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
+import devkor.com.teamcback.domain.bookmark.repository.UserBookmarkLogRepository;
+import devkor.com.teamcback.domain.suggestion.entity.Suggestion;
+import devkor.com.teamcback.domain.suggestion.repository.SuggestionRepository;
 import devkor.com.teamcback.domain.user.dto.request.LoginUserReq;
+import devkor.com.teamcback.domain.user.dto.response.DeleteUserRes;
 import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
 import devkor.com.teamcback.domain.user.dto.response.LoginUserRes;
 import devkor.com.teamcback.domain.user.dto.response.ModifyUsernameRes;
@@ -13,6 +22,7 @@ import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
 import devkor.com.teamcback.global.exception.GlobalException;
 import devkor.com.teamcback.global.jwt.JwtUtil;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +40,9 @@ import static devkor.com.teamcback.global.response.ResultCode.*;
 public class UserService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final UserBookmarkLogRepository userBookmarkLogRepository;
+    private final SuggestionRepository suggestionRepository;
     private final JwtUtil jwtUtil;
     private static final String DEFAULT_NAME = "호랑이";
     private static final String DEFAULT_CATEGORY = "내 장소";
@@ -86,6 +99,32 @@ public class UserService {
         user.updateUsername(username);
 
         return new ModifyUsernameRes();
+    }
+
+    /**
+     * 사용자 회원 탈퇴
+     */
+    public DeleteUserRes deleteUser(Long userId) {
+        User user = findUser(userId);
+
+        List<Category> categoryList = categoryRepository.findByUser(user);
+        for(Category category : categoryList) {
+            // 각 북마크가 다른 카테고리와 연결되어 있지 않은지 확인 후 삭제
+            category.getCategoryBookmarkList().forEach(categoryBookmark -> {
+                Bookmark bookmark = categoryBookmark.getBookmark();
+                if (bookmark.getCategoryBookmarkList().size() == 1) {
+                    bookmarkRepository.delete(bookmark);
+                }
+            });
+
+            categoryRepository.delete(category);
+        }
+
+        userBookmarkLogRepository.deleteAll(userBookmarkLogRepository.findByUser(user));
+        suggestionRepository.deleteAll(suggestionRepository.findByUser(user));
+        userRepository.delete(user);
+
+        return new DeleteUserRes();
     }
 
     private void checkInvalidUsername(String username) {

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -104,10 +104,12 @@ public class UserService {
     /**
      * 사용자 회원 탈퇴
      */
+    @Transactional
     public DeleteUserRes deleteUser(Long userId) {
         User user = findUser(userId);
 
         List<Category> categoryList = categoryRepository.findByUser(user);
+
         for(Category category : categoryList) {
             // 각 북마크가 다른 카테고리와 연결되어 있지 않은지 확인 후 삭제
             category.getCategoryBookmarkList().forEach(categoryBookmark -> {


### PR DESCRIPTION
## 개요
회원 탈퇴 기능 추가

## 작업사항
- 회원 탈퇴 시 기존 데이터를 모두 삭제하고 회원을 삭제
- 카테고리 삭제 시 즐겨찾기가 삭제되지 않는 오류 수정

## 관련 이슈
- 회원 탈퇴 후 FE에서 토큰 처리 및 로그인 화면으로 이동하면 될 것 같아서 따로 토큰에 대한 처리는 하지 않았습니다.
