### PR TITLE
Fix: routing bugfix

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/controller/RouteController.java
@@ -83,12 +83,19 @@ public class RouteController {
             endLocation.add(endId.doubleValue());
         }
         List<GetRouteRes> returnList = new ArrayList<>();
-        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, conditions));
+        List<Conditions> newCondition;
+        if (conditions == null) {
+            newCondition = new ArrayList<>();
+            returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, newCondition));
+        }
+        else{
+            returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, conditions));
+        }
 
         //presentation 후 없앨 코드
-        List<Conditions> newCondition = conditions;
+        newCondition = conditions;
         newCondition.add(Conditions.BARRIERFREE);
-        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, conditions));
+        returnList.add(routeService.findRoute(startLocation, startType, endLocation, endType, newCondition));
         return CommonResponse.success(returnList);
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -70,7 +70,7 @@ public class RouteService {
         List<Building> buildingList = getBuildingsForRoute(startNode, endNode);
         GetGraphRes graphRes = getGraph(buildingList, startNode, endNode, conditions);
         DijkstraRes route = dijkstra(graphRes.getGraphNode(), graphRes.getGraphEdge(), startNode, endNode);
-        if (route.getPath().isEmpty()) throw new GlobalException(NOT_FOUND_ROUTE);
+        //if (route.getPath().isEmpty()) throw new GlobalException(NOT_FOUND_ROUTE); 임시로 제거
         return buildRouteResponse(route, isStartBuilding, isEndBuilding);
     }
 
@@ -106,6 +106,8 @@ public class RouteService {
      * 경로 생성 메서드
      */
     private GetRouteRes buildRouteResponse(DijkstraRes route, boolean isStartBuilding, boolean isEndBuilding) {
+        if (route.getPath().isEmpty()) return new GetRouteRes(1);//경로 미탐색 막기 위해 임의로 추가
+
         Long duration = route.getDistance();
         List<List<Node>> path = cutRoute(route.getPath(), isStartBuilding, isEndBuilding);
 


### PR DESCRIPTION
## 개요
dev 기준으로 코드 수정하는 김에 그냥 버그를 수정해서 정상적인 탐색이 가능하도록 했습니다.

## 작업사항
- 버그 탐색 및 수정으로 정상적인 일반 경로/배리어프리 경로 이중 탐색 가능
- 두 경로 중 하나가 없을 때, 에러코드 리턴이 아닌 description=1, 나머지 모두 빈 리스트 리턴하도록 함
- 추후 프론트엔드 작업 시 파라미터 conditions에 제한사항 넣기만 하면 즉시 이용 가능

## 관련 이슈
- 
