### PR TITLE
노드 관리용 예외 처리 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -509,10 +509,6 @@ public class RouteService {
         return buildingRepository.findById(buildingId).orElseThrow(() -> new GlobalException(NOT_FOUND_BUILDING));
     }
 
-    private Building findBuildingByNode(Node node){
-        return buildingRepository.findBuildingByNode(node);
-    }
-
     private Place findPlace(Long placeId) {
         return placeRepository.findById(placeId).orElseThrow(() -> new GlobalException(NOT_FOUND_PLACE));
     }

--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -489,7 +489,7 @@ public class RouteService {
             if(!adjacentNode.getBuilding().equals(node.getBuilding())) return adjacentNode.getBuilding();
         }
 
-        throw new AdminException(INCORRECT_NODE_DATA,node.getId() + "에 연결된 건물이 없습니다");
+        throw new AdminException(INCORRECT_NODE_DATA,node.getId() + "번 노드에 연결된 건물이 없습니다");
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -489,7 +489,7 @@ public class RouteService {
             if(!adjacentNode.getBuilding().equals(node.getBuilding())) return adjacentNode.getBuilding();
         }
 
-        throw new AdminException(INCORRECT_NODE_DATA,"연결된 건물이 없습니다");
+        throw new AdminException(INCORRECT_NODE_DATA,node.getId() + "에 연결된 건물이 없습니다");
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/devkor/com/teamcback/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,12 @@ public class GlobalExceptionHandler {
             .body(new CommonResponse<>(e.getResultCode()));
     }
 
+    @ExceptionHandler(AdminException.class)
+    public ResponseEntity<CommonResponse<String>> handleException(AdminException e) {
+        return ResponseEntity.status(e.getResultCode().getStatus())
+            .body(new CommonResponse<>(e.getResultCode(), e.getAdminMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<String>> handleValidationError(
         MethodArgumentNotValidException e) { // Validation 예외를 잡아줌


### PR DESCRIPTION
## 개요
노드 관리를 위한 예외 클래스를 만들었는데 예외 처리를 하지 않았어서 추가합니다!
swagger 등으로 어떤 노드에서 오류가 나는지 확인하기 위해 추가한 거라 FE에는 영향이 없을 것 같습니다.

## 작업사항
- AdminException 핸들러 추가, data 필드에 AdminMessage 반환 추가
- 사용하지 않는 메서드 삭제

## 관련 이슈
- 
