### PR TITLE
비회원 건의 작성 가능하도록 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
@@ -1,7 +1,5 @@
 package devkor.com.teamcback.domain.suggestion.controller;
 
-import devkor.com.teamcback.domain.bookmark.dto.request.CreateCategoryReq;
-import devkor.com.teamcback.domain.bookmark.dto.response.CreateCategoryRes;
 import devkor.com.teamcback.domain.suggestion.dto.request.CreateSuggestionReq;
 import devkor.com.teamcback.domain.suggestion.dto.response.CreateSuggestionRes;
 import devkor.com.teamcback.domain.suggestion.service.SuggestionService;

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
@@ -40,10 +40,11 @@ public class SuggestionController {
     })
     @PostMapping
     public CommonResponse<CreateSuggestionRes> createSuggestion(
-        @Parameter(description = "사용자정보", required = true)
+        @Parameter(description = "사용자정보")
         @AuthenticationPrincipal UserDetailsImpl userDetail,
         @Parameter(description = "건의 제목, 분류, 내용", required = true)
         @RequestBody CreateSuggestionReq req) {
-        return CommonResponse.success(suggestionService.createSuggestion(userDetail.getUser().getUserId(), req));
+        Long userId = userDetail == null ? null : userDetail.getUser().getUserId();
+        return CommonResponse.success(suggestionService.createSuggestion(userId, req));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
@@ -33,13 +33,16 @@ public class SuggestionService {
      */
     @Transactional
     public CreateSuggestionRes createSuggestion(Long userId, CreateSuggestionReq req) {
-        User user = findUser(userId);
+        User user = null;
+        if(userId != null) user = findUser(userId);
         Suggestion suggestion = new Suggestion(req, user);
 
         Suggestion savedSuggestion = suggestionRepository.save(suggestion);
 
         //건의 생성 시 score 증가
-        user.updateScore(user.getScore() + 3);
+        if(user != null) {
+            user.updateScore(user.getScore() + 3);
+        }
 
         return new CreateSuggestionRes(savedSuggestion);
     }

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/routes/**").permitAll()
                 .requestMatchers("/api/koyeon/**").permitAll() // 고연전 이후 삭제 필요
                 .requestMatchers("/api/users/login").permitAll()
+                .requestMatchers("/api/suggestions/**").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용
                 .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/swagger-ui.html").permitAll()


### PR DESCRIPTION
## 개요
비회원 건의 작성 가능하도록 수정

## 작업사항
- SecurityConfig에서 api/suggestions 허용
- 비회원인 경우 User를 null로 건의 저장

## 관련 이슈
- 
