### PR TITLE
Fix: 기본 길탐색 셔틀 경로 제거

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -192,15 +192,9 @@ public class RouteService {
         Map<Long, List<Edge>> graphEdge = new HashMap<>();
 
         // 조건에 따른 노드 검색
-        if (conditions == null || conditions.isEmpty()){
-            for (Building building : buildingList){
-                graphNode.addAll(findAllNode(building));
-            }
-        }
-        else{
-            for (Building building : buildingList){
-                graphNode.addAll(findNodeWithConditions(building, conditions));
-            }
+
+        for (Building building : buildingList){
+            graphNode.addAll(findNodeWithConditions(building, conditions));
         }
 
         if (!graphNode.contains(startNode)){
@@ -246,13 +240,14 @@ public class RouteService {
      */
     private List<Node> findNodeWithConditions(Building building, List<Conditions> conditions){
         List<NodeType> nodeTypes = new ArrayList<>(Arrays.asList(NodeType.NORMAL, NodeType.STAIR, NodeType.ELEVATOR, NodeType.ENTRANCE, NodeType.CHECKPOINT));
-        if (conditions.contains(BARRIERFREE)){
-            nodeTypes.remove(NodeType.STAIR);
+        if (conditions != null){
+            if (conditions.contains(BARRIERFREE)){
+                nodeTypes.remove(NodeType.STAIR);
+            }
+            else if (conditions.contains(Conditions.SHUTTLE)){
+                nodeTypes.add(NodeType.SHUTTLE);
+            }
         }
-        else if (conditions.contains(Conditions.SHUTTLE)){
-            nodeTypes.add(NodeType.SHUTTLE);
-        }
-
         return nodeRepository.findByBuildingAndRoutingAndTypeIn(building, true, nodeTypes);
     }
 


### PR DESCRIPTION
## 개요
기본 길탐색 셔틀 경로 제거

## 작업사항
- 기존 코드의 getGraph에서는 condition이 없는 경우 building 기준으로 탐색하였는데, 이 경우 모든 노드를 다 탐색하게 되어 shuttle 노드까지 포함됩니다. findNodeWithConditions에서는 condition이 없는 경우에도 기본 탐색 노드들이 설정되기에, 무조건 findNodeWithConditions를 이용하여 노드 탐색하도록 수정하였습니다.

- findNodeWithConditions에서 condition에 null이 들어오는 경우(condition이 없는 경우) 오류를 방지하는 코드를 추가하였습니다.

