### PR TITLE
Fix: 실내-실외 구분 오류 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingRepository.java
@@ -3,7 +3,13 @@ package devkor.com.teamcback.domain.building.repository;
 import devkor.com.teamcback.domain.building.entity.Building;
 import devkor.com.teamcback.domain.routes.entity.Node;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
-    Building findBuildingByNode(Node node);
+    @Query(value = "SELECT * FROM tb_building WHERE node_id IN :nodeIds", nativeQuery = true)
+    Optional<Building> findByNodeIdIn(@Param("nodeIds") Long[] nodeIds);
 }

--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -479,12 +479,8 @@ public class RouteService {
      */
     private Building findLinkedBuilding(Node node){
         Long[] adjacentNodeIds = convertStringToArray(node.getAdjacentNode());
-        for (Long nodeId: adjacentNodeIds){
-            Node adjacentNode = findNode(nodeId);
-            if(!adjacentNode.getBuilding().equals(node.getBuilding())) return adjacentNode.getBuilding();
-        }
-
-        throw new AdminException(INCORRECT_NODE_DATA,node.getId() + "번 노드에 연결된 건물이 없습니다");
+        return buildingRepository.findByNodeIdIn(adjacentNodeIds)
+            .orElseThrow(() -> new AdminException(INCORRECT_NODE_DATA,node.getId() + "번 노드에 연결된 건물이 없습니다"));
     }
 
     /**


### PR DESCRIPTION
## 개요
- 실내노드가 없을 때, 길찾기 오류가 발생하는 경우 수정 

## 작업사항
- 하나의 Entrance가 2개의 Building과 연결되어 있는 경우는 없기 때문에 실외-실내의 연결을 찾는 것이 아닌, adjacentNodes 중 building에 해당하는 노드가 있는지 확인하는 방식으로 변경하였습니다.
- BuildingRepository에서 NativeQuery를 활용하여, Node 객체를 찾지 않고도 node_id 만으로도 조회할 수 있도록 하였습니다.
->총 DB 조회 횟수가 1번으로 줄어들었습니다.

## 관련 이슈
- 시각적인 확인이 어려워 오류 여부만 확인했는데 다른 문제가 있다면 말씀주시면 감사하겠습니다! 
