### PR TITLE
Feat: 유효하지 않은 토큰, 탈퇴한 사용자 예외 처리 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
@@ -1,7 +1,7 @@
 package devkor.com.teamcback.domain.user.validator;
 
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_TOKEN;
 import static devkor.com.teamcback.global.response.ResultCode.LOG_IN_REQUIRED;
-import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
 
 import devkor.com.teamcback.domain.user.validator.client.AppleClient;
 import devkor.com.teamcback.global.exception.GlobalException;
@@ -51,7 +51,7 @@ public class AppleValidator {
 
             return payload.getSub();
         } catch (Exception e) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(INVALID_TOKEN);
         }
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
@@ -1,7 +1,7 @@
 package devkor.com.teamcback.domain.user.validator;
 
 import static devkor.com.teamcback.global.response.ResultCode.LOG_IN_REQUIRED;
-import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_TOKEN;
 
 import devkor.com.teamcback.domain.user.validator.client.GoogleClient;
 import devkor.com.teamcback.global.exception.GlobalException;
@@ -47,7 +47,7 @@ public class GoogleValidator {
 
             return payload.getEmail();
         } catch (Exception e) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(INVALID_TOKEN);
         }
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
@@ -1,7 +1,7 @@
 package devkor.com.teamcback.domain.user.validator;
 
 import static devkor.com.teamcback.global.response.ResultCode.LOG_IN_REQUIRED;
-import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_TOKEN;
 
 import devkor.com.teamcback.domain.user.validator.client.KakaoClient;
 import devkor.com.teamcback.global.exception.GlobalException;
@@ -46,7 +46,7 @@ public class KakaoValidator{
 
             return payload.getEmail();
         } catch (Exception e) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(INVALID_TOKEN);
         }
     }
 }

--- a/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
@@ -46,7 +46,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         // access token 검증
         switch(jwtUtil.validateToken(accessToken)) {
             case VALID -> setAuthentication(jwtUtil.getUserIdFromToken(accessToken));
-            case INVALID -> throw new GlobalException(UNAUTHORIZED);
+            case INVALID -> throw new GlobalException(INVALID_TOKEN);
             case EXPIRED -> authenticateRefreshToken(request, response);
         }
 
@@ -81,7 +81,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         switch(jwtUtil.validateToken(refreshToken)) {
             case VALID -> renewAccessToken(response, refreshToken);
-            case INVALID ->  throw new GlobalException(UNAUTHORIZED); // Unauthorized
+            case INVALID ->  throw new GlobalException(INVALID_TOKEN);
             case EXPIRED -> throw new GlobalException(REFRESH_TOKEN_EXPIRED);
         }
     }

--- a/src/main/java/devkor/com/teamcback/global/jwt/OIDC/OIDCUtil.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/OIDC/OIDCUtil.java
@@ -1,6 +1,6 @@
 package devkor.com.teamcback.global.jwt.OIDC;
 
-import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_TOKEN;
 
 import devkor.com.teamcback.global.exception.GlobalException;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCDecodePayload;
@@ -35,13 +35,13 @@ public class OIDCUtil {
                 .build()
                 .parseClaimsJwt(getUnsignedToken(token));
         } catch (Exception e) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(INVALID_TOKEN);
         }
     }
 
     private String getUnsignedToken(String token) {
         String[] splitToken = token.split("\\.");
-        if (splitToken.length != 3) throw new GlobalException(UNAUTHORIZED);
+        if (splitToken.length != 3) throw new GlobalException(INVALID_TOKEN);
         return splitToken[0] + "." + splitToken[1] + ".";
     }
 
@@ -61,7 +61,7 @@ public class OIDCUtil {
                 .build()
                 .parseClaimsJws(token);
         } catch (Exception e) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -10,15 +10,17 @@ public enum ResultCode {
     // 글로벌 1000번대
     SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, 1000, "잘못된 입력값입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1001, "권한이 없는 사용자입니다."),
-    REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, 1002, "Refresh Token이 필요합니다."),
-    LOG_IN_REQUIRED(HttpStatus.UNAUTHORIZED, 1004, "다시 로그인 해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 토큰입니다."), // 로그인 관련
+    REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, 1002, "Refresh Token이 필요합니다."), // 로그인 관련
+    LOG_IN_REQUIRED(HttpStatus.UNAUTHORIZED, 1004, "다시 로그인 해주세요."), // 로그인 관련
     SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1005, "서버 시스템 문제가 발생했습니다."),
     ILLEGAL_REGISTRATION_ID(HttpStatus.BAD_REQUEST, 1006, "지원하는 소셜이 아닙니다."),
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, 1007, "지원하는 파일 형식이 아닙니다."),
     MAXIMUM_UPLOAD_FILE_SIZE(HttpStatus.BAD_REQUEST, 1008, "파일 크기는 최대 10MB까지 가능합니다."),
     NOT_FOUND_FILE(HttpStatus.NOT_FOUND, 1009, "파일을 찾을 수 없습니다."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1010, "Refresh Token이 만료되었습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1010, "Refresh Token이 만료되었습니다."), // 로그인 관련
+    DELETED_USER(HttpStatus.UNAUTHORIZED, 1011, "탈퇴한 사용자입니다."), // 로그인 관련
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1012, "권한이 없는 사용자입니다."),
 
     // 사용자 2000번대
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2000, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/devkor/com/teamcback/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/devkor/com/teamcback/global/security/UserDetailsServiceImpl.java
@@ -1,6 +1,6 @@
 package devkor.com.teamcback.global.security;
 
-import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
+import static devkor.com.teamcback.global.response.ResultCode.DELETED_USER;
 
 import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
@@ -22,7 +22,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         User user = userRepository.findByUserId(Long.parseLong(userId));
         if(user == null) {
-            throw new GlobalException(NOT_FOUND_USER);
+            throw new GlobalException(DELETED_USER);
         }
         return UserDetailsImpl.builder().user(user).build();
     }


### PR DESCRIPTION
## 개요
'권한없음' 예외 처리 중 FE에서 로그인 화면으로 돌아가는 예외 처리(유효하지 않은 토큰 등)와 실제로 권한이 없는 예외 처리(다른 사람의 즐겨찾기를 조회 등)를 구분하기 위해 전자를 유효하지 않은 토큰 예외 처리로 추가 및 수정했습니다.
한 사람이 여러 기기에서 로그인 한 후 하나에서 탈퇴했을 경우에도 로그인 처리하기 위해 토큰 내 userId에 해당하는 사용자가 없는 경우는 탈퇴 예외 처리로 수정했습니다.

## 작업사항
- 유효하지 않은 토큰 예외 처리 추가(토큰 관련 권한 없음 예외 처리를 수정)
- 탈퇴한 사용자 예외 처리 추가(필터에서 토큰 userId에 해당하는 사용자가 없을 때를 수정)

## 관련 이슈
- 
