### PR TITLE
Fix: 예외 처리 오류 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
@@ -50,6 +50,8 @@ public class AppleValidator {
             OIDCDecodePayload payload = oidcUtil.getOIDCTokenBody(token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
 
             return payload.getSub();
+        } catch(GlobalException e) {
+            throw new GlobalException(LOG_IN_REQUIRED);
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
@@ -46,6 +46,8 @@ public class GoogleValidator {
             OIDCDecodePayload payload = oidcUtil.getOIDCTokenBody(token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
 
             return payload.getEmail();
+        } catch(GlobalException e) {
+            throw new GlobalException(LOG_IN_REQUIRED);
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
@@ -45,6 +45,8 @@ public class KakaoValidator{
             OIDCDecodePayload payload = oidcUtil.getOIDCTokenBody(token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
 
             return payload.getEmail();
+        } catch(GlobalException e) {
+            throw new GlobalException(LOG_IN_REQUIRED);
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }


### PR DESCRIPTION
## 개요
throw한 예외를 제대로 처리하지 않은 부분이 있어서 수정합니다!

## 작업사항
- 소셜 공개키가 일치하지 않는 경우에는 재로그인 요청 예외 처리를, 그 외 문제는 유효하지 않은 토큰 예외 처리를 하도록 수정

## 관련 이슈
- 
