### PR TITLE
필터 인증 예외 처리 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
@@ -65,7 +65,7 @@ public class BookmarkService {
             for (Long selectCategoryId : req.getCategoryIdList()) {
                 if (!userCategoryList.stream().map(Category::getId).toList()
                     .contains(selectCategoryId)) {
-                    throw new GlobalException(UNAUTHORIZED);
+                    throw new GlobalException(FORBIDDEN);
                 }
             }
 
@@ -145,7 +145,7 @@ public class BookmarkService {
 
     private void checkAuthority(User user, Bookmark bookmark) {
         if(bookmark.getCategoryBookmarkList().stream().noneMatch(categoryBookmark -> categoryBookmark.getCategory().getUser().getUserId().equals(user.getUserId()))) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(FORBIDDEN);
         }
     }
 

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/CategoryService.java
@@ -180,7 +180,7 @@ public class CategoryService {
 
     private void checkAuthority(User accessor, User owner) {
         if(!accessor.getUserId().equals(owner.getUserId())) {
-            throw new GlobalException(UNAUTHORIZED);
+            throw new GlobalException(FORBIDDEN);
         }
     }
 

--- a/src/main/java/devkor/com/teamcback/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/devkor/com/teamcback/global/exception/CustomAccessDeniedHandler.java
@@ -1,11 +1,10 @@
 package devkor.com.teamcback.global.exception;
 
-import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+import static devkor.com.teamcback.global.response.ResultCode.FORBIDDEN;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.response.ResultCode;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -14,18 +13,18 @@ import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
-public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+public class CustomAccessDeniedHandler implements AccessDeniedHandler{
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
         AccessDeniedException accessDeniedException) {
         ObjectMapper objectMapper = new ObjectMapper();
-        response.setStatus(UNAUTHORIZED.getStatus().value());
+        response.setStatus(FORBIDDEN.getStatus().value());
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         try {
             response.getWriter().write(objectMapper.writeValueAsString(
-                new CommonResponse<>(UNAUTHORIZED)));
+                new CommonResponse<>(FORBIDDEN)));
         } catch (IOException e) {
             throw new GlobalException(ResultCode.SYSTEM_ERROR);
         }

--- a/src/main/java/devkor/com/teamcback/global/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/devkor/com/teamcback/global/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package devkor.com.teamcback.global.exception;
+
+import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.com.teamcback.global.response.CommonResponse;
+import devkor.com.teamcback.global.response.ResultCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(UNAUTHORIZED.getStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(
+                new CommonResponse<>(UNAUTHORIZED)));
+        } catch (IOException e) {
+            throw new GlobalException(ResultCode.SYSTEM_ERROR);
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -20,7 +20,8 @@ public enum ResultCode {
     NOT_FOUND_FILE(HttpStatus.NOT_FOUND, 1009, "파일을 찾을 수 없습니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1010, "Refresh Token이 만료되었습니다."), // 로그인 관련
     DELETED_USER(HttpStatus.UNAUTHORIZED, 1011, "탈퇴한 사용자입니다."), // 로그인 관련
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1012, "권한이 없는 사용자입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1012, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, 1013, "권한이 없는 사용자입니다."),
 
     // 사용자 2000번대
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2000, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.global.security;
 
 import devkor.com.teamcback.global.exception.CustomAccessDeniedHandler;
+import devkor.com.teamcback.global.exception.CustomAuthenticationEntryPoint;
 import devkor.com.teamcback.global.exception.ExceptionHandlerFilter;
 import devkor.com.teamcback.global.jwt.JwtAuthorizationFilter;
 import devkor.com.teamcback.global.jwt.JwtUtil;
@@ -60,6 +61,11 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CustomAuthenticationEntryPoint customAuthenticationEntryPoint() {
+        return new CustomAuthenticationEntryPoint();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         // CSRF 설정
         http.csrf(AbstractHttpConfigurer::disable);
@@ -82,8 +88,9 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui.html").permitAll()
                 .requestMatchers("/api-docs/**").permitAll()
                 .anyRequest().authenticated() // 그 외 모든 요청 인증처리
-        ).exceptionHandling((exceptionHandling) -> exceptionHandling
-            .accessDeniedHandler(customAccessDeniedHandler())
+        ).exceptionHandling(ex -> ex
+            .accessDeniedHandler(customAccessDeniedHandler()) // 인가 실패 시
+            .authenticationEntryPoint(customAuthenticationEntryPoint()) // 인증 실패 시
         );
 
         http.logout(


### PR DESCRIPTION
## 개요
토큰이 없을 때 인증이 필요한 요청을 한 경우 예외 처리 요청이 있어 추가합니다.

## 작업사항
- 401: 인증이 되지 않았을 때 인증이 필요한 경우
- 403: 인증이 되었지만 권한이 없는 경우
- 403용 예외 처리를 추가하여 기존 unauthorized 예외를 상황에 맞게 분리하였습니다.

## 관련 이슈
- 
