### PR TITLE
Fix: 길찾기 오류 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -329,7 +329,15 @@ public class RouteService {
         List<List<Node>> path = cutRoute(route.getPath()); // 분할된 경로
 
         //시작, 끝이 건물인 경우 해당 노드 지우기
-        if (isStartBuilding) path.remove(0);
+        //시작, 끝이 건물인 경우 해당 노드 지우기
+        if (isStartBuilding) {
+            // 첫번째 path의 길이에 따라 삭제 다르게 하기
+            if(path.get(0).size() > 1) {
+                path.get(0).remove(0);
+            } else {
+                path.remove(0);
+            }
+        }
         if (isEndBuilding) path.get(path.size()-1).remove(path.get(path.size()-1).size()-1);
 
         List<PartialRouteRes> totalRoute = new ArrayList<>();

--- a/src/test/java/devkor/com/teamcback/integration/RouteServiceIntegrationTest.java
+++ b/src/test/java/devkor/com/teamcback/integration/RouteServiceIntegrationTest.java
@@ -1,25 +1,22 @@
 package devkor.com.teamcback.integration;
 
 import devkor.com.teamcback.BaseMvcTest;
+import devkor.com.teamcback.domain.building.entity.Building;
+import devkor.com.teamcback.domain.building.repository.BuildingRepository;
 import devkor.com.teamcback.domain.routes.entity.LocationType;
 import devkor.com.teamcback.domain.routes.entity.Node;
 import devkor.com.teamcback.domain.routes.repository.NodeRepository;
 import devkor.com.teamcback.domain.routes.service.RouteService;
 import devkor.com.teamcback.global.exception.AdminException;
 import devkor.com.teamcback.global.exception.GlobalException;
-import java.util.List;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 @Disabled
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -32,6 +29,9 @@ public class RouteServiceIntegrationTest extends BaseMvcTest {
 
     @Autowired
     NodeRepository nodeRepository;
+
+    @Autowired
+    BuildingRepository buildingRepository;
 
     @Test
     @Order(1)
@@ -47,6 +47,27 @@ public class RouteServiceIntegrationTest extends BaseMvcTest {
                     System.out.println(e.getAdminMessage());
                 } catch (GlobalException e) {
                     System.out.println(e.getResultCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("기본 길찾기 테스트: 빌딩 - 빌딩")
+    void buildingRouteTest() {
+        List<Building> buildingList = buildingRepository.findAll();
+        for(Building start : buildingList) {
+            for (Building end : buildingList) {
+                if(start.getId() != 0 && end.getId() != 0 && !start.getId().equals(end.getId())) {
+                    try {
+                        System.out.println("start_building_id: " + start.getId() + " end_building_id: " + end.getId());
+                        routeService.findRoute(LocationType.BUILDING, start.getId(), null, null, LocationType.BUILDING, end.getId(), null, null, null);
+                    } catch (AdminException e) {
+                        System.out.println(e.getAdminMessage());
+                    } catch (GlobalException e) {
+                        System.out.println(e.getResultCode());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 개요
첫 노드가 building인 경우, 노드가 아닌 첫 path를 삭제하는 오류가 있어서 수정하였습니다.


## 작업사항
- 첫 노드 만을 지울 경우, 경로에 따라 빈리스트로 인한 오류가 발생하는 경우가 있어 case를 구분하였습니다.

## 관련 이슈
- 전체 경로 확인 시간이 너무 오래 걸려 일단 빌딩-빌딩 경우의 테스트만 완료하였습니다. 다른 경로에서 문제가 발생한다면 말씀주시면 감사하겠습니다!