### PR TITLE
DB 관련 오류 예외 처리

### DIFF
--- a/src/main/java/devkor/com/teamcback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/devkor/com/teamcback/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,9 @@ package devkor.com.teamcback.global.exception;
 
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.response.ResultCode;
+import jakarta.validation.ConstraintViolationException;
+import java.sql.SQLException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -39,5 +42,11 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(new CommonResponse<>(ResultCode.INVALID_INPUT, sb.toString()));
+    }
+
+    @ExceptionHandler({SQLException.class, DataAccessException.class, ConstraintViolationException.class})
+    public ResponseEntity<CommonResponse<String>> handleDBException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new CommonResponse<>(ResultCode.DB_ERROR, ex.getMessage()));
     }
 }

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -22,6 +22,7 @@ public enum ResultCode {
     DELETED_USER(HttpStatus.UNAUTHORIZED, 1011, "탈퇴한 사용자입니다."), // 로그인 관련
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1012, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, 1013, "권한이 없는 사용자입니다."),
+    DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1014, "DB 데이터 문제가 발생했습니다."),
 
     // 사용자 2000번대
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2000, "사용자를 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
중복된 값이 있는 경우, DB에 직접 넣어서 관리 프로그램 통해서 데이터를 넣을 때 입력 오류가 나는 경우 등이 401 예외로 나와 구분하기 힘들어 관리를 위해 예외 처리 추가했습니다.

## 작업사항
- DB 관련 오류를 핸들링하고 에러 메시지를 반환하도록 추가

## 관련 이슈
- 
