### PR TITLE
Fix: 소셜 로그인 예외 처리 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/AppleValidator.java
@@ -9,6 +9,7 @@ import devkor.com.teamcback.global.jwt.OIDC.OIDCUtil;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCDecodePayload;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeyDto;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeysResponse;
+import devkor.com.teamcback.global.redis.RedisUtil;
 import io.jsonwebtoken.Header;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class AppleValidator {
     private final OIDCUtil oidcUtil;
     private final AppleClient appleClient;
+    private final RedisUtil redisUtil;
     private static final String KID = "kid";
     private static final String ALG = "alg";
 
@@ -51,7 +53,8 @@ public class AppleValidator {
 
             return payload.getSub();
         } catch(GlobalException e) {
-            throw new GlobalException(LOG_IN_REQUIRED);
+            redisUtil.deleteCache("apple::data");
+            throw new GlobalException(e.getResultCode());
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/GoogleValidator.java
@@ -9,6 +9,7 @@ import devkor.com.teamcback.global.jwt.OIDC.OIDCUtil;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCDecodePayload;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeyDto;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeysResponse;
+import devkor.com.teamcback.global.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class GoogleValidator {
     private final OIDCUtil oidcUtil;
     private final GoogleClient googleClient;
+    private final RedisUtil redisUtil;
 
     @Value("${jwt.social.google.iss}")
     private String ISS;
@@ -46,7 +48,8 @@ public class GoogleValidator {
 
             return payload.getEmail();
         } catch(GlobalException e) {
-            throw new GlobalException(LOG_IN_REQUIRED);
+            redisUtil.deleteCache("google::data");
+            throw new GlobalException(e.getResultCode());
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
@@ -9,6 +9,7 @@ import devkor.com.teamcback.global.jwt.OIDC.OIDCUtil;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCDecodePayload;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeyDto;
 import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCPublicKeysResponse;
+import devkor.com.teamcback.global.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class KakaoValidator{
     private final OIDCUtil oidcUtil;
     private final KakaoClient kakaoClient;
+    private final RedisUtil redisUtil;
 
     @Value("${jwt.social.kakao.iss}")
     private String ISS;
@@ -46,7 +48,8 @@ public class KakaoValidator{
 
             return payload.getEmail();
         } catch(GlobalException e) {
-            throw new GlobalException(LOG_IN_REQUIRED);
+            redisUtil.deleteCache("kakao::data");
+            throw new GlobalException(e.getResultCode());
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }

--- a/src/main/java/devkor/com/teamcback/domain/user/validator/client/AppleClient.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/client/AppleClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @FeignClient(name = "appleClient", url = "https://appleid.apple.com")
 public interface AppleClient {
-    @Cacheable(value = "apple")
+    @Cacheable(value = "apple", key = "'data'")
     @GetMapping("/auth/keys")
     OIDCPublicKeysResponse getPublicKeys();
 }

--- a/src/main/java/devkor/com/teamcback/global/redis/RedisUtil.java
+++ b/src/main/java/devkor/com/teamcback/global/redis/RedisUtil.java
@@ -35,5 +35,9 @@ public class RedisUtil {
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
+
+    public void deleteCache(String key) {
+        redisTemplate.delete(key);
+    }
 }
 


### PR DESCRIPTION
## 개요
소셜 로그인 예외 처리 수정

## 작업사항
- 애플 캐싱 데이터 키 값 설정
- 소셜 예외 처리 오류 수정
- 캐싱된 값이 일치하지 않을 경우 기존 값을 삭제하도록 수정

## 관련 이슈
- 
