### PR TITLE
Fix: cutRoute 버그 패치

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/routes/service/RouteService.java
@@ -423,7 +423,7 @@ public class RouteService {
                 partialRoute.add(thisNode);
 
                 // 계단/엘리베이터를 통한 연속적인 층 이동을 감지하여 중간 층을 생략
-                while (count < route.size() - 1 && !Objects.equals(thisNode.getFloor(), nextNode.getFloor())) {
+                while (count < route.size() - 1 && !Objects.equals(thisNode.getFloor(), nextNode.getFloor()) && thisNode.getBuilding().equals(nextNode.getBuilding())) {
                     thisNode = route.get(count);
                     nextNode = route.get(count + 1);
                     count++;
@@ -433,6 +433,7 @@ public class RouteService {
 
                 // 끝 층의 시작 노드를 새 경로로 추가
                 partialRoute.add(thisNode);
+                count--;
             }
             else {
                 partialRoute.add(thisNode);


### PR DESCRIPTION
## 개요
cutRoute 버그 패치

## 작업사항
- 층 이동 도중에 건물을 이동해버리면 cutRoute에서 감지되지 않는 오류 수정
- 층 연속이동 후 count++가 한번 더 일어나는 것을 방지하기 위해 count-- 추가
## 관련 이슈

