### PR TITLE
Fix: 공백 무관 검색 기능 추가

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/building/entity/BuildingNickname.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/entity/BuildingNickname.java
@@ -44,4 +44,10 @@ public class BuildingNickname extends BaseEntity {
         this.chosung = chosung;
         this.jasoDecompose = jasoDecompose;
     }
+
+    public void update(String nickname, String chosung, String jasoDecompose) {
+        this.nickname = nickname;
+        this.chosung = chosung;
+        this.jasoDecompose = jasoDecompose;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/building/repository/BuildingNicknameRepository.java
@@ -12,4 +12,5 @@ public interface BuildingNicknameRepository extends JpaRepository<BuildingNickna
     List<BuildingNickname> findAllByJasoDecomposeContaining(String jaso);
     List<BuildingNickname> findByChosungIsNullOrJasoDecomposeIsNull();
     List<BuildingNickname> findAllByBuilding(Building building);
+    List<BuildingNickname> findAllByNicknameContaining(String blank);
 }

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceNickname.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceNickname.java
@@ -38,4 +38,10 @@ public class PlaceNickname extends BaseEntity {
         this.chosung = chosung;
         this.jasoDecompose = jasoDecompose;
     }
+
+    public void update(String nickname, String chosung, String jasoDecompose) {
+        this.nickname = nickname;
+        this.chosung = chosung;
+        this.jasoDecompose = jasoDecompose;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/place/repository/PlaceNicknameRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/repository/PlaceNicknameRepository.java
@@ -16,4 +16,5 @@ public interface PlaceNicknameRepository extends JpaRepository<PlaceNickname, Lo
     List<PlaceNickname> findByChosungContainingAndPlaceInOrderByNickname(String chosung, List<Place> list, Pageable pageable);
     List<PlaceNickname> findByJasoDecomposeContainingAndPlaceInOrderByNickname(String jaso, List<Place> list, Pageable pageable);
     List<PlaceNickname> findByChosungIsNullOrJasoDecomposeIsNull();
+    List<PlaceNickname> findAllByNicknameContaining(String blank);
 }

--- a/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/service/SearchService.java
@@ -356,8 +356,8 @@ public class SearchService {
 
     private List<Building> getBuildings(String word) {
         // 건물 조회
-        List<BuildingNickname> buildingNicknames = buildingNicknameRepository.findAllByJasoDecomposeContaining(hangeulUtils.decomposeHangulString(word));
-        if(hangeulUtils.isConsonantOnly(word)) buildingNicknames.addAll(buildingNicknameRepository.findAllByChosungContaining(hangeulUtils.extractChosung(word)));
+        List<BuildingNickname> buildingNicknames = buildingNicknameRepository.findAllByJasoDecomposeContaining(hangeulUtils.decomposeHangulString(word.replace(" ", "")));
+        if(hangeulUtils.isConsonantOnly(word)) buildingNicknames.addAll(buildingNicknameRepository.findAllByChosungContaining(hangeulUtils.extractChosung(word.replace(" ", ""))));
 
         // 중복을 제거하여 List에 저장
         return buildingNicknames.stream()
@@ -507,9 +507,9 @@ public class SearchService {
         List<PlaceNickname> placeNicknames;
         List<Place> resultPlaces = new ArrayList<>();
         if(building != null && !places.isEmpty()) { // 빌딩 제한 있는 경우
-            placeNicknames = placeNicknameRepository.findByJasoDecomposeContainingAndPlaceInOrderByNickname(hangeulUtils.decomposeHangulString(word), places, limit);
+            placeNicknames = placeNicknameRepository.findByJasoDecomposeContainingAndPlaceInOrderByNickname(hangeulUtils.decomposeHangulString(word.replace(" ", "")), places, limit);
             // 초성으로만 구성된 경우
-            if(hangeulUtils.isConsonantOnly(word)) placeNicknames.addAll(placeNicknameRepository.findByChosungContainingAndPlaceInOrderByNickname(hangeulUtils.extractChosung(word), places, limit));
+            if(hangeulUtils.isConsonantOnly(word)) placeNicknames.addAll(placeNicknameRepository.findByChosungContainingAndPlaceInOrderByNickname(hangeulUtils.extractChosung(word.replace(" ", "")), places, limit));
 
             // 중복을 제거하여 List에 저장
             resultPlaces.addAll(placeNicknames.stream()
@@ -520,7 +520,7 @@ public class SearchService {
             // 빌딩 + 편의시설명의 경우를 GlobalSearchRes로 추가하기 (Ex. 하나스퀘어 카페)
             // word가 편의시설명과 부분일치하는지 확인하기(outerTagTypes) && 빌딩에 해당 시설이 있는지 확인
             for (PlaceType type : outerTagTypes) {
-                if((type.getName().contains(word) || Arrays.stream(type.getNickname()).anyMatch(nickname -> nickname.contains(word)))) {
+                if((type.getName().contains(word) || Arrays.stream(type.getNickname()).anyMatch(nickname -> nickname.contains(word.replace(" ", ""))))) {
                     List<Place> tempPlace = placeRepository.findAllByBuildingAndType(building, type);
                     if(!tempPlace.isEmpty()) {
                         resultPlaces.addAll(tempPlace);
@@ -531,9 +531,9 @@ public class SearchService {
             }
         }
         else if(building == null) { // 빌딩 제한 없는 전체 검색
-            placeNicknames = placeNicknameRepository.findAllByJasoDecomposeContainingOrderByNickname(hangeulUtils.decomposeHangulString(word), limit);
+            placeNicknames = placeNicknameRepository.findAllByJasoDecomposeContainingOrderByNickname(hangeulUtils.decomposeHangulString(word.replace(" ", "")), limit);
             // 초성으로만 구성된 경우
-            if(hangeulUtils.isConsonantOnly(word)) placeNicknames.addAll( placeNicknameRepository.findAllByChosungContainingOrderByNickname(hangeulUtils.extractChosung(word), limit));
+            if(hangeulUtils.isConsonantOnly(word)) placeNicknames.addAll( placeNicknameRepository.findAllByChosungContainingOrderByNickname(hangeulUtils.extractChosung(word.replace(" ", "")), limit));
 
             // 중복을 제거하여 List에 저장
             resultPlaces.addAll(placeNicknames.stream()
@@ -543,7 +543,7 @@ public class SearchService {
 
             // 자체가 편의시설명인 경우 : 야외 태그
             for (PlaceType type : outerTagTypes) {
-                if(type.getName().contains(word) || Arrays.stream(type.getNickname()).anyMatch(nickname -> nickname.contains(word))) {
+                if(type.getName().contains(word.replace(" ", "")) || Arrays.stream(type.getNickname()).anyMatch(nickname -> nickname.contains(word.replace(" ", "")))) {
                     resultPlaces.add(new Place(type, findBuilding(0L)));
                 }
             }


### PR DESCRIPTION
## 개요
공백 무관 검색 기능을 추가하였습니다.

## 작업사항
- Place/Building에 대해 공백과 무관한 검색이 가능하도록 수정하였습니다. (.replace(" ", "") 메소드 사용)
- 기존 Nicknames 테이블 수정 API에 공백 제거 로직을 추가하였습니다.

## 관련 이슈
- 빌딩/장소의 경우 처음과 끝 공백을 기준으로 나누기 때문에, 여전히 빌딩+장소의 경우 문제가 생길 수도 있습니다. 그러나 기존의 검색에서도 동일한 문제가 존재하기 때문에 로직을 추가해 보았습니다.
- DB의 업데이트는 로컬로 돌려서 완료하였습니다.