### PR TITLE
운영 시간 스케줄러를 위한 분산 락 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ ext {
 }
 
 dependencies {
+    // Redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/OperatingScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/operatingtime/scheduler/OperatingScheduler.java
@@ -3,6 +3,7 @@ package devkor.com.teamcback.domain.operatingtime.scheduler;
 import devkor.com.teamcback.domain.operatingtime.entity.DayOfWeek;
 import devkor.com.teamcback.domain.operatingtime.service.HolidayService;
 import devkor.com.teamcback.domain.operatingtime.service.OperatingService;
+import devkor.com.teamcback.global.redis.RedisLockUtil;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class OperatingScheduler {
     private final OperatingService operatingService;
     private final HolidayService holidayService;
+    private final RedisLockUtil redisLockUtil;
 
     private static final int SUMMER_VACATION_START_MONTH = 6;
     private static final int SUMMER_VACATION_START_DAY = 22;
@@ -39,39 +41,42 @@ public class OperatingScheduler {
     @EventListener(ApplicationReadyEvent.class)
     public void updateOperatingTime() {
         setState();
-
         log.info("운영 시간 업데이트");
-        operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
+
+        redisLockUtil.executeWithLock("lock", 1, 300, () -> {
+            operatingService.updateOperatingTime(dayOfWeek, isHoliday, isVacation, isEvenWeek);
+            return null;
+        });
     }
 
 
 //    @Scheduled(cron = "30 35 * * * *") // 테스트용
     @Scheduled(cron = "0 */10 9-18 * * *") // 10분마다
     public void updateOperatingDuringPeakHour() {
-        setState();
-
         log.info("운영 여부 업데이트");
-        LocalTime nowTime = LocalTime.now();
-
-        operatingService.updateIsOperating(nowTime, dayOfWeek, isHoliday, isVacation, isEvenWeek);
+        redisLockUtil.executeWithLock("lock", 1, 300, () -> {
+            operatingService.updateIsOperating(LocalTime.now(), dayOfWeek, isHoliday, isVacation, isEvenWeek);
+            return null;
+        });
     }
 
     @Scheduled(cron = "0 0,30 0-8,19-23 * * *") // 30분마다
     public void updateOperating() {
-        setState();
-
         log.info("운영 여부 업데이트");
-        LocalTime nowTime = LocalTime.now();
-
-        operatingService.updateIsOperating(nowTime, dayOfWeek, isHoliday, isVacation, isEvenWeek);
+        redisLockUtil.executeWithLock("lock", 1, 300, () -> {
+            operatingService.updateIsOperating(LocalTime.now(), dayOfWeek, isHoliday, isVacation, isEvenWeek);
+            return null;
+        });
     }
 
     // 장소 운영 시간 저장 - 건물의 운영 시간에 변동이 있을 경우 1회 작동
     @EventListener(ApplicationReadyEvent.class)
     public void updatePlaceOperatingTime() {
         log.info("장소 운영 시간 업데이트");
-
-        operatingService.updatePlaceOperatingTime();
+        redisLockUtil.executeWithLock("lock", 1, 300, () -> {
+            operatingService.updatePlaceOperatingTime();
+            return null;
+        });
     }
 
     private void setState() {

--- a/src/main/java/devkor/com/teamcback/global/redis/RedisConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/redis/RedisConfig.java
@@ -1,6 +1,9 @@
 package devkor.com.teamcback.global.redis;
 
 import devkor.com.teamcback.domain.search.entity.SearchLog;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +57,15 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(SearchLog.class));
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress("redis://" + host + ":" + port)
+            .setPassword(password);
+        return Redisson.create(config);
     }
 
 }

--- a/src/main/java/devkor/com/teamcback/global/redis/RedisLockUtil.java
+++ b/src/main/java/devkor/com/teamcback/global/redis/RedisLockUtil.java
@@ -1,0 +1,44 @@
+package devkor.com.teamcback.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisLockUtil {
+
+    private final RedissonClient redissonClient;
+
+    /**
+     * 분산 락을 활용하여 특정 작업 실행
+     *
+     * @param lockKey   락 키 (ex: "scheduler_lock")
+     * @param waitTime  락을 기다리는 시간 (초)
+     * @param leaseTime 락 유지 시간 (초)
+     * @param task      실행할 작업 (람다식으로 전달)
+     */
+    public <T> void executeWithLock(String lockKey, long waitTime, long leaseTime, Supplier<T> task) {
+        RLock lock = redissonClient.getLock(lockKey);
+        try {
+            if (lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
+                try {
+                    task.get();
+                } finally {
+                    lock.unlock();
+                }
+            } else {
+                log.info("다른 서버에서 실행 중이므로 종료");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}
+

--- a/src/test/java/devkor/com/teamcback/RedissonLockTest.java
+++ b/src/test/java/devkor/com/teamcback/RedissonLockTest.java
@@ -1,0 +1,37 @@
+package devkor.com.teamcback;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class RedissonLockTest {
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+//    @Test
+    public void testLockAcquisition() throws InterruptedException {
+        String lockKey = "test_lock";
+        RLock lock = redissonClient.getLock(lockKey);
+
+        // 락을 획득할 수 있는지 확인
+        boolean isLocked = lock.tryLock(1, 5, TimeUnit.SECONDS);
+        assertThat(isLocked).isTrue(); // 정상적으로 락을 획득해야 함
+
+        // 락 해제
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
+    }
+}
+

--- a/src/test/java/devkor/com/teamcback/RedissonMultiThreadTest.java
+++ b/src/test/java/devkor/com/teamcback/RedissonMultiThreadTest.java
@@ -1,0 +1,56 @@
+package devkor.com.teamcback;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class RedissonMultiThreadTest {
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    private final String lockKey = "test_lock";
+
+//    @Test
+    public void testConcurrentLocking() throws InterruptedException {
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                RLock lock = redissonClient.getLock(lockKey);
+                try {
+                    if (lock.tryLock(1, 5, TimeUnit.SECONDS)) {
+                        System.out.println("🔒 락 획득: " + Thread.currentThread().getName());
+                        Thread.sleep(1000); // 1초 동안 락 유지
+                    } else {
+                        System.out.println("❌ 락 획득 실패: " + Thread.currentThread().getName());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    if (lock.isHeldByCurrentThread()) {
+                        lock.unlock();
+                        System.out.println("🔓 락 해제: " + Thread.currentThread().getName());
+                    }
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 종료될 때까지 대기
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
## 개요
여러 서버가 동일한 시간에 동일한 데이터에 대하여 운영 시간 스케줄러를 실행하는 것을 막기 위해 분산 락을 추가했습니다.

## 작업사항
- Redis를 이용한 네임드 락을 지원하는 Redisson 사용하여 스케줄러 작동 시 특정 키값을 가진 락을 설정함으로써 서버 1대에서만 스케줄러가 작동하도록 함
- 테스트 코드는 gpt의 도움을 받았습니다. (주석처리함)

## 관련 이슈
- commit을 잘못해서 엉망진창입니다...
