### PR TITLE
Feat: 별명 수정 시 비속어 확인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ ext {
 }
 
 dependencies {
+    // 비속어 라이브러리
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+
     // Redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
 

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package devkor.com.teamcback.domain.user.service;
 
+import com.vane.badwordfiltering.BadWordFiltering;
 import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
 import devkor.com.teamcback.domain.bookmark.entity.Color;
@@ -203,6 +204,12 @@ public class UserService {
         // username이 입력되지 않은 경우
         if(username.isEmpty()) {
             throw new GlobalException(EMPTY_USERNAME);
+        }
+
+        // 비속어 확인
+        BadWordFiltering badWordFiltering = new BadWordFiltering();
+        if (badWordFiltering.blankCheck(username)) {
+            throw new GlobalException(BAD_WORD_IN_USERNAME);
         }
     }
 

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -31,6 +31,7 @@ public enum ResultCode {
     USERNAME_IN_USE(HttpStatus.IM_USED, 2002, "현재 설정된 별명과 다른 별명을 입력해주세요."),
     INCORRECT_LEVEL(HttpStatus.BAD_REQUEST, 2003, "존재하지 않는 레벨입니다."),
     EMPTY_USERNAME(HttpStatus.BAD_REQUEST, 2004, "별명을 입력해주세요."),
+    BAD_WORD_IN_USERNAME(HttpStatus.BAD_REQUEST, 2005, "별명에는 비속어가 포함될 수 없습니다."),
 
     // 건물 3000번대
     NOT_FOUND_BUILDING(HttpStatus.NOT_FOUND, 3000, "건물을 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
별명 수정 시 비속어 확인 추가

## 작업사항
- 별명 유효성 검증 메서드에 비속어가 있으면 예외를 던지도록 추가했습니다.

## 관련 이슈
- 사용한 라이브러리: https://github.com/VaneProject/bad-word-filtering
