### PR TITLE
Docs: Swagger 건의 사진 입력 가능하도록 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/controller/SuggestionController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,7 +37,7 @@ public class SuggestionController {
         @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다.",
             content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<CreateSuggestionRes> createSuggestion(
             @Parameter(description = "사용자정보")
         @AuthenticationPrincipal UserDetailsImpl userDetail,


### PR DESCRIPTION
## 개요
Swagger 건의 사진 입력 가능하도록 수정

## 작업사항
- SuggestionContoller에 consumes = MediaType.MULTIPART_FORM_DATA_VALUE를 추가하여 여러 이미지를 Swagger에서 입력 가능하도록 수정했습니다.

## 관련 이슈
- 
