### PR TITLE
Fix : 유저 Score 증가 로직 AOP 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // lombok 테스트용
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/dto/request/CreateBookmarkReq.java
@@ -2,11 +2,14 @@ package devkor.com.teamcback.domain.bookmark.dto.request;
 
 import devkor.com.teamcback.domain.common.LocationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @Schema(description = "장소타입, 장소 id (건물 or 강의실 or 편의시설), 메모")
 @Getter
+@AllArgsConstructor
 public class CreateBookmarkReq {
     @Schema(description = "카테고리 id 리스트", example = "[1, 2, 3]")
     private List<Long> categoryIdList;

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
@@ -72,12 +72,6 @@ public class BookmarkService {
                 }
             }
 
-            Bookmark bookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(req.getLocationId(), req.getLocationType(), userCategoryList);
-            if(bookmark == null) {
-                bookmark = bookmarkRepository.save(new Bookmark(req));
-            }
-
-
             for (Category category : userCategoryList) {
                 boolean isSelected = req.getCategoryIdList().contains(category.getId());
                 Bookmark existedBookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(
@@ -91,6 +85,11 @@ public class BookmarkService {
                     deleteCategoryBookmark(categoryBookmark);
                 } else if (existedBookmark == null && isSelected) { // 북마크 x -> 선택 o
                     // 해당 카테고리의 북마크 생성
+                    Bookmark bookmark = bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(req.getLocationId(), req.getLocationType(), userCategoryList);
+                    if(bookmark == null) {
+                        bookmark = bookmarkRepository.save(new Bookmark(req));
+                    }
+
                     CategoryBookmark categoryBookmark = new CategoryBookmark();
                     categoryBookmark.setCategoryAndBookmark(category, bookmark);
                     categoryBookmarkRepository.save(categoryBookmark);

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/dto/request/CreateSuggestionReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/dto/request/CreateSuggestionReq.java
@@ -3,10 +3,12 @@ package devkor.com.teamcback.domain.suggestion.dto.request;
 import devkor.com.teamcback.domain.suggestion.entity.SuggestionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Schema(description = "건의 제목, 분류, 내용")
 @Getter
+@AllArgsConstructor
 public class CreateSuggestionReq {
     @Schema(description = "제목", example = "장소 위치가 잘못됨")
     private String title;

--- a/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/devkor/com/teamcback/domain/suggestion/service/SuggestionService.java
@@ -13,6 +13,7 @@ import devkor.com.teamcback.domain.suggestion.entity.SuggestionType;
 import devkor.com.teamcback.domain.suggestion.repository.SuggestionRepository;
 import devkor.com.teamcback.domain.user.entity.User;
 import devkor.com.teamcback.domain.user.repository.UserRepository;
+import devkor.com.teamcback.global.annotation.UpdateScore;
 import devkor.com.teamcback.global.exception.exception.GlobalException;
 import devkor.com.teamcback.infra.s3.FilePath;
 import devkor.com.teamcback.infra.s3.S3Util;
@@ -40,6 +41,7 @@ public class SuggestionService {
      * 건의 생성
      */
     @Transactional
+    @UpdateScore(addScore = 3)
     public CreateSuggestionRes createSuggestion(Long userId, CreateSuggestionReq req, List<MultipartFile> images) {
         User user = null;
         if(userId != null) user = findUser(userId);
@@ -56,11 +58,6 @@ public class SuggestionService {
         suggestion.setImages(suggestionImages);
 
         Suggestion savedSuggestion = suggestionRepository.save(suggestion);
-
-        //건의 생성 시 score 증가
-        if(user != null) {
-            user.updateScore(user.getScore() + 3);
-        }
 
         return new CreateSuggestionRes(savedSuggestion);
     }

--- a/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/dto/response/GetUserInfoRes.java
@@ -25,11 +25,13 @@ public class GetUserInfoRes {
     private Long remainScoreToNextLevel;
     @Schema(description = "percent", example = "75")
     private int percent;
+    @Schema(description = "isUpgraded", example = "true")
+    private boolean isUpgraded;
     @Schema(description = "categoryCount", example = "2")
     private Long categoryCount;
     //TODO: 이웃 수, 게시물 수 정보 추가하기
 
-    public GetUserInfoRes(User user, Long categoryCount, int level, Long remainScoreToNextLevel, int percent) {
+    public GetUserInfoRes(User user, Long categoryCount, int level, Long remainScoreToNextLevel, int percent, boolean isUpgraded) {
         this.username = user.getUsername();
         this.email = user.getEmail();
         this.provider = user.getProvider();
@@ -38,6 +40,7 @@ public class GetUserInfoRes {
         this.score = user.getScore();
         this.remainScoreToNextLevel = remainScoreToNextLevel;
         this.percent = percent;
+        this.isUpgraded = isUpgraded;
         this.categoryCount = categoryCount;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/entity/User.java
@@ -38,6 +38,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Long score = 0L;
 
+    @Column(nullable = false)
+    private boolean isUpgraded = false;
+
     @Setter
     @Column(unique = true)
     private String code;
@@ -48,13 +51,20 @@ public class User extends BaseEntity {
         this.role = role;
         this.provider = provider;
         this.score = 0L;
+        this.isUpgraded = false;
     }
 
     public void updateUsername(String username) {
         this.username = username;
     }
-    public void updateScore(Long score) {
+
+    public void updateScore(Long score, boolean isUpgraded) {
         this.score = score;
+        this.isUpgraded = isUpgraded;
+    }
+
+    public void updateUpgraded(boolean isUpgraded) {
+        this.isUpgraded = isUpgraded;
     }
 
 }

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -65,7 +65,7 @@ public class UserService {
     /**
      * 마이페이지 정보 조회
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public GetUserInfoRes getUserInfo(Long userId) {
         User user = findUser(userId);
         Level level = getLevel(user.getScore());
@@ -75,7 +75,14 @@ public class UserService {
         if(nextLevel != null) {
             percent = (int) (100 * (user.getScore() - level.getMinScore()) / (nextLevel.getMinScore() - level.getMinScore()));
         }
-        return new GetUserInfoRes(user, categoryRepository.countAllByUser(user), level.getLevelNumber(), remainScoreToNextLevel, percent);
+
+        //조회 후 isUpgraded = false로 업데이트
+        boolean isUpgraded = user.isUpgraded();
+        if(isUpgraded) {
+            user.updateUpgraded(false);
+        }
+
+        return new GetUserInfoRes(user, categoryRepository.countAllByUser(user), level.getLevelNumber(), remainScoreToNextLevel, percent, isUpgraded);
     }
 
     /**

--- a/src/main/java/devkor/com/teamcback/global/annotation/UpdateScore.java
+++ b/src/main/java/devkor/com/teamcback/global/annotation/UpdateScore.java
@@ -1,0 +1,13 @@
+package devkor.com.teamcback.global.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface UpdateScore {
+    int addScore();
+}

--- a/src/main/java/devkor/com/teamcback/global/aop/UpdateScoreAspect.java
+++ b/src/main/java/devkor/com/teamcback/global/aop/UpdateScoreAspect.java
@@ -1,0 +1,109 @@
+package devkor.com.teamcback.global.aop;
+
+import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.repository.UserBookmarkLogRepository;
+import devkor.com.teamcback.domain.user.entity.Level;
+import devkor.com.teamcback.domain.user.entity.User;
+import devkor.com.teamcback.domain.user.repository.UserRepository;
+import devkor.com.teamcback.global.annotation.UpdateScore;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UpdateScoreAspect {
+
+    private boolean needUpdate = true;
+    private User user = null;
+    private int addScore;
+
+    private final UserRepository userRepository;
+    private final UserBookmarkLogRepository userBookmarkLogRepository;
+
+    @Before("@annotation(updateScore)")
+    public void checkUpdatable(JoinPoint joinPoint, UpdateScore updateScore) {
+        log.info("AOP 확인 절차 수행");
+
+        // score 저장
+        addScore = updateScore.addScore();
+
+        // User 정보 찾기 (매개변수 검사로 찾기)
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+
+        for (int i = 0; i < args.length; i++) {
+            if (paramNames[i].equals("user") && args[i] instanceof User) {
+                user = (User) args[i];
+                break;
+            } else if (paramNames[i].equals("userId") && args[i] instanceof Long userId) {
+                user = userRepository.findById(userId).orElseThrow(() -> new GlobalException(NOT_FOUND_USER));
+                break;
+            }
+        }
+
+        // 유저 정보가 없으면 AOP 실행하지 않음
+        if (user == null) {
+            log.warn("user 또는 userId 부재");
+            needUpdate = false;
+            return;
+        }
+
+        // 유저 정보 로깅
+        log.info("User : {}", user.getUserId());
+
+        for (Object arg : args) {
+            // 북마크 추가 시 점수 증가 여부 확인
+            if (arg instanceof CreateBookmarkReq req) {
+                if (userBookmarkLogRepository.existsByUserAndLocationIdAndLocationType(user, req.getLocationId(), req.getLocationType())) {
+                    log.info("중복 Log: 점수가 증가하지 않습니다.");
+                    needUpdate = false;
+                    return;
+                }
+            }
+        }
+    }
+
+    @AfterReturning(pointcut = "@annotation(devkor.com.teamcback.global.annotation.UpdateScore)")
+    public void updateScore () {
+        log.info("AOP 호출");
+
+        // 점수 증가 필요한 경우에만 로직 실행
+        if (needUpdate) increaseScore(user);
+    }
+
+    public void increaseScore(User user) {
+        long newScore = user.getScore() + addScore;
+        // 이전 레벨 계산
+        Level beforeLv = getLevel(user.getScore());
+        Level afterLv = getLevel(newScore);
+
+        // 변했으면 true
+        boolean isChanged = beforeLv != afterLv;
+        if(isChanged) log.info("레벨 변경: {} -> {}", beforeLv.name(), afterLv.name());
+
+        user.updateScore(newScore, isChanged);
+        log.info("점수 증가: {} {}", user.getUserId(), newScore);
+    }
+
+    private Level getLevel(Long score) {
+        // score >= minScore 인 경우 중 가장 높은 레벨 반환
+        return Arrays.stream(Level.values())
+            .filter(lv -> score >= lv.getMinScore())
+            .max(Comparator.comparingInt(Level::getMinScore))
+            .orElse(Level.LEVEL1);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/global/aop/UpdateScoreAspect.java
+++ b/src/main/java/devkor/com/teamcback/global/aop/UpdateScoreAspect.java
@@ -59,7 +59,6 @@ public class UpdateScoreAspect {
             // 북마크 추가 시 점수 증가 여부 확인 (중복 로그 확인)
             if (arg instanceof CreateBookmarkReq req) {
                 if (userBookmarkLogRepository.existsByUserAndLocationIdAndLocationType(user, req.getLocationId(), req.getLocationType())) {
-                    log.info("중복 Log: 점수가 증가하지 않습니다.");
                     needUpdate = false;
                 }
             }
@@ -88,10 +87,7 @@ public class UpdateScoreAspect {
 
         // 변했으면 true
         boolean isChanged = beforeLv != afterLv;
-        if(isChanged) log.info("레벨 변경: {} -> {}", beforeLv.name(), afterLv.name());
-
         user.updateScore(newScore, isChanged);
-        log.info("점수 증가: {} {}", user.getUserId(), newScore);
     }
 
     private Level getLevel(Long score) {

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
 
 @Slf4j
-@Disabled
+//@Disabled
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class UpdateScoreAspectTest {
@@ -83,7 +83,7 @@ public class UpdateScoreAspectTest {
 
         list.add(96L); // 카테고리 ID : 새 로그 검사용
         LocationType type = LocationType.PLACE;
-        long placeId = 61L;
+        long placeId = 66L;
         String memo = "memo";
 
         User user = findUser(userId);
@@ -125,7 +125,15 @@ public class UpdateScoreAspectTest {
         user = findUser(userId);
         long againScore = user.getScore();
         log.info("북마크 재생성 후 Score : " + againScore);
-        Assertions.assertThat(afterScore).isEqualTo(againScore);
+        Assertions.assertThat(againScore).isEqualTo(afterScore);
+
+        // 4. 동일 북마크 다시 넣었을 때 점수 증가 X
+        bookmarkService.createBookmark(userId, req);
+
+        user = findUser(userId);
+        long dupScore = user.getScore();
+        log.info("중복 북마크 생성 후 Score (저장X) : " + dupScore);
+        Assertions.assertThat(dupScore).isEqualTo(againScore);
     }
 
     private User findUser(Long userId) {

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -43,7 +43,6 @@ public class UpdateScoreAspectTest {
     private BookmarkService bookmarkService;
 
     @Test
-    @Disabled
     public void suggestionScoreTest() {
         Long userId = 36L; // 임시로 제 계정 사용했습니다.
         User user = findUser(userId);
@@ -77,14 +76,13 @@ public class UpdateScoreAspectTest {
     }
 
     @Test
-    @Disabled
     public void bookmarkScoreTest() {
         Long userId = 36L; // 임시로 제 계정 사용했습니다.
         List<Long> list = new ArrayList<>();
 
         list.add(96L); // 카테고리 ID : 새 로그 검사용
         LocationType type = LocationType.PLACE;
-        long placeId = 58L;
+        long placeId = 60L;
         String memo = "memo";
 
         User user = findUser(userId);
@@ -116,17 +114,17 @@ public class UpdateScoreAspectTest {
             log.info("레벨이 오르지 않았습니다.");
         }
 
-//        // 3. 다른 카테고리에 동일 장소 북마크 추가 : 점수 증가X
-//        log.info("북마크 재생성 전 Score : " + afterScore);
-//        list.clear();
-//        list.add(99L);
-//        req = new CreateBookmarkReq(list, type, placeId, memo);
-//        bookmarkService.createBookmark(userId, req);
-//
-//        user = findUser(userId);
-//        long againScore = user.getScore();
-//        log.info("북마크 재생성 후 Score : " + againScore);
-//        Assertions.assertThat(afterScore).isEqualTo(againScore);
+        // 3. 다른 카테고리에 동일 장소 북마크 추가 : 점수 증가X
+        log.info("북마크 재생성 전 Score : " + afterScore);
+        list.clear();
+        list.add(99L);
+        req = new CreateBookmarkReq(list, type, placeId, memo);
+        bookmarkService.createBookmark(userId, req);
+
+        user = findUser(userId);
+        long againScore = user.getScore();
+        log.info("북마크 재생성 후 Score : " + againScore);
+        Assertions.assertThat(afterScore).isEqualTo(againScore);
     }
 
     private User findUser(Long userId) {

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
 
 @Slf4j
-//@Disabled
+@Disabled
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class UpdateScoreAspectTest {

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -36,6 +36,7 @@ public class UpdateScoreAspectTest {
 
     @Autowired
     private UserService userService;
+
     @Autowired
     private SuggestionService suggestionService;
 
@@ -82,7 +83,7 @@ public class UpdateScoreAspectTest {
 
         list.add(96L); // 카테고리 ID : 새 로그 검사용
         LocationType type = LocationType.PLACE;
-        long placeId = 60L;
+        long placeId = 61L;
         String memo = "memo";
 
         User user = findUser(userId);

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -1,0 +1,134 @@
+package devkor.com.teamcback.global.aop;
+
+import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.service.BookmarkService;
+import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.suggestion.dto.request.CreateSuggestionReq;
+import devkor.com.teamcback.domain.suggestion.entity.SuggestionType;
+import devkor.com.teamcback.domain.suggestion.service.SuggestionService;
+import devkor.com.teamcback.domain.user.dto.response.GetUserInfoRes;
+import devkor.com.teamcback.domain.user.entity.User;
+import devkor.com.teamcback.domain.user.repository.UserRepository;
+import devkor.com.teamcback.domain.user.service.UserService;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class UpdateScoreAspectTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private SuggestionService suggestionService;
+
+    @Autowired
+    private BookmarkService bookmarkService;
+
+    @Test
+    @Disabled
+    public void suggestionScoreTest() {
+        Long userId = 36L; // 임시로 제 계정 사용했습니다.
+        User user = findUser(userId);
+        CreateSuggestionReq req = new CreateSuggestionReq("Test제목", SuggestionType.INCONVENIENCE, "내용", "이메일");
+
+        // 건의함 작성 시 포인트 확인
+        long beforeScore = user.getScore();
+        log.info("건의함 작성 전 Score : " + beforeScore);
+        suggestionService.createSuggestion(userId, req, null);
+
+        user = findUser(userId);
+        long afterScore = user.getScore();
+        log.info("건의함 작성 후 Score : " + afterScore);
+        Assertions.assertThat(beforeScore+3).isEqualTo(afterScore);
+
+        // 점수가 기준치를 넘었는지 확인
+        if(user.isUpgraded()) {
+            log.info("레벨이 올랐습니다.");
+
+            // 업그레이드 후 마이페이지 첫 조회
+            GetUserInfoRes info = userService.getUserInfo(userId);
+            log.info("마이페이지 isUgraded : " + info.isUpgraded());
+            Assertions.assertThat(info.isUpgraded()).isTrue(); // True
+
+            user = findUser(userId); // 조회 후 User 정보
+            log.info("조회 후 isUpgraded : " + user.isUpgraded());
+            Assertions.assertThat(user.isUpgraded()).isFalse(); // false
+        } else {
+            log.info("레벨이 오르지 않았습니다.");
+        }
+    }
+
+    @Test
+    @Disabled
+    public void bookmarkScoreTest() {
+        Long userId = 36L; // 임시로 제 계정 사용했습니다.
+        List<Long> list = new ArrayList<>();
+
+        list.add(96L); // 카테고리 ID : 새 로그 검사용
+        LocationType type = LocationType.PLACE;
+        long placeId = 58L;
+        String memo = "memo";
+
+        User user = findUser(userId);
+        CreateBookmarkReq req = new CreateBookmarkReq(list, type, placeId, memo);
+
+        // 1. 건의함 작성 시 포인트 확인
+        long beforeScore = user.getScore();
+        log.info("북마크 생성 전 Score : " + beforeScore);
+        bookmarkService.createBookmark(userId, req);
+
+        user = findUser(userId);
+        long afterScore = user.getScore();
+        log.info("북마크 생성 후 Score : " + afterScore);
+        Assertions.assertThat(beforeScore+1).isEqualTo(afterScore);
+
+        // 2. 점수가 기준치를 넘었는지 확인
+        if(user.isUpgraded()) {
+            log.info("레벨이 올랐습니다.");
+
+            // 업그레이드 후 마이페이지 첫 조회
+            GetUserInfoRes info = userService.getUserInfo(userId);
+            log.info("마이페이지 isUgraded : " + info.isUpgraded());
+            Assertions.assertThat(info.isUpgraded()).isTrue(); // True
+
+            user = findUser(userId); // 조회 후 User 정보
+            log.info("조회 후 isUpgraded : " + user.isUpgraded());
+            Assertions.assertThat(user.isUpgraded()).isFalse(); // false
+        } else {
+            log.info("레벨이 오르지 않았습니다.");
+        }
+
+//        // 3. 다른 카테고리에 동일 장소 북마크 추가 : 점수 증가X
+//        log.info("북마크 재생성 전 Score : " + afterScore);
+//        list.clear();
+//        list.add(99L);
+//        req = new CreateBookmarkReq(list, type, placeId, memo);
+//        bookmarkService.createBookmark(userId, req);
+//
+//        user = findUser(userId);
+//        long againScore = user.getScore();
+//        log.info("북마크 재생성 후 Score : " + againScore);
+//        Assertions.assertThat(afterScore).isEqualTo(againScore);
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new GlobalException(NOT_FOUND_USER));
+    }
+}

--- a/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
+++ b/src/test/java/devkor/com/teamcback/global/aop/UpdateScoreAspectTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_USER;
 
 @Slf4j
+@Disabled
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class UpdateScoreAspectTest {


### PR DESCRIPTION
## 개요
- 유저 Score 증가 로직을 AOP로 수정하였습니다.
    - 건의함 추가 : 항상 증가
    - 북마크 추가 :  로그가 존재하지 않으면 증가
- tb_user 테이블에 isUpgraded 필드를 추가하여 레벨업 팝업 여부를 판단할 수 있도록 수정하였습니다.
- 마이페이지 조회 API에 isUpgraded 필드를 추가하였습니다.

## 작업사항
- 점수 증가 기준을 메소드 단위로 적용하는 것이 편할 것 같아서 커스텀 어노테이션을 제작하였습니다. `@UpdateScore` 이 붙은 경우 AOP가 적용됩니다.
- 어노테이션 내부의 addScore 필드를 통해 증가시키고 싶은 값을 유동적으로 받아올 수 있습니다.

(이전)
- 점수 증가 여부가 내부 로직에 따라 달라지는 경우가 있어 Advice를 2가지로 작성하였습니다. (`@Before`, `@AfterReturning`)
- 전체 흐름
    - `@Before` 로 호출 전 필요 정보를 필드에 저장 + 점수 증가 여부 확인
    - 비즈니스 로직 수행
    - 검사 플래그(needUpdate) 가 true인 경우에만 점수 증가 로직을 수행

(수정 후)
- `@Around`로 호출 전/후 로직 통합
  
- 만약 점수 증가 후 레벨이 달라진다면, isUpgraded를 true로 갱신합니다.
- 이후 마이페이지 조회 API를 호출하면, 해당 값을 추가적으로 반환하고 isUpgraded를 다시 false로 갱신합니다. (일회성)

## 관련 이슈
- 제가 아직 테스트 코드에 익숙하지 않아서 검사 로직이 지저분하고 길어졌는데 더 나은 방법이 있다면 말씀주시면 감사하겠습니다!
