### PR TITLE
Refactor: 즐겨찾기 관련 repository 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/entity/Bookmark.java
@@ -35,7 +35,6 @@ public class Bookmark extends BaseEntity {
         this.memo = req.getMemo();
         this.locationType = req.getLocationType();
         this.locationId = req.getLocationId();
-
     }
 
     public void update(String memo) {

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepository.java
@@ -4,18 +4,23 @@ import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
 import devkor.com.teamcback.domain.common.LocationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
-    List<Bookmark> findAllByCategoryBookmarkList_CategoryId(Long categoryId);
+    @Query("select cb.bookmark from CategoryBookmark cb where cb.category.id = :categoryId")
+    List<Bookmark> findAllByCategoryBookmarkList_CategoryId(@Param("categoryId") Long categoryId);
 
-    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(Long locationId, LocationType locationType, Category category);
+    @Query("select b from Bookmark b join b.categoryBookmarkList cb where b.locationId = :locationId and b.locationType = :locationType and cb.category = :category")
+    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(@Param("locationId")Long locationId, @Param("locationType")LocationType locationType, @Param("category")Category category);
 
-    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(Long locationId, LocationType locationType,
-        List<Category> userCategoryList);
+    @Query("select b from Bookmark b join b.categoryBookmarkList cb where b.locationId = :locationId and b.locationType = :locationType and cb.category IN :categories")
+    Bookmark findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(@Param("locationId")Long locationId, @Param("locationType")LocationType locationType,
+                                                                               @Param("categories")List<Category> userCategoryList);
 
-    boolean existsByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(Long locationId, LocationType locationType,
-        List<Category> categories);
+    @Query("select case when count(b) > 0 then true else false end from Bookmark b join b.categoryBookmarkList cb where b.locationId = :locationId and b.locationType = :locationType and cb.category IN :categories")
+    boolean existsByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(@Param("locationId")Long locationId, @Param("locationType")LocationType locationType,
+                                                                                @Param("categories") List<Category> categories);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryBookmarkRepository.java
@@ -4,15 +4,14 @@ import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
 import devkor.com.teamcback.domain.bookmark.entity.Category;
 import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
 import devkor.com.teamcback.domain.common.LocationType;
-import devkor.com.teamcback.domain.user.entity.User;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryBookmarkRepository extends JpaRepository<CategoryBookmark, Long> {
     boolean existsByCategoryAndBookmark(Category category, Bookmark bookmark);
 
     Optional<CategoryBookmark> findByCategoryAndBookmark(Category category, Bookmark bookmark);
 
-    CategoryBookmark findByCategoryAndBookmarkLocationIdAndBookmarkLocationType(Category category, Long locationId, LocationType type);
 }

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/repository/CategoryRepository.java
@@ -13,10 +13,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findAllByUser(User user);
     Long countAllByUser(User user);
 
-    @Query("SELECT c FROM CategoryBookmark cb " +
-        "JOIN cb.category c " +
-        "JOIN cb.bookmark b " +
-        "WHERE c.user = :user AND b.locationType = :locationType AND b.locationId = :locationId")
+    @Query("""
+        SELECT c FROM CategoryBookmark cb
+        JOIN cb.category c
+        JOIN cb.bookmark b
+        WHERE c.user = :user AND b.locationType = :locationType AND b.locationId = :locationId
+        """)
     List<Category> findCategoriesByUserAndLocationTypeAndLocationId(
         @Param("user") User user,
         @Param("locationType") LocationType locationType,

--- a/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/devkor/com/teamcback/domain/bookmark/service/BookmarkService.java
@@ -154,15 +154,6 @@ public class BookmarkService {
         }
     }
 
-    private void checkPlaceDuplication(Category category, LocationType locationType, Long locationId) {
-        CategoryBookmark categoryBookmark = categoryBookmarkRepository.findByCategoryAndBookmarkLocationIdAndBookmarkLocationType(category, locationId, locationType);
-
-        // 같은 카테고리에 동일 북마크가 존재하는 경우
-        if (categoryBookmark != null) {
-            throw new GlobalException(DUPLICATED_BOOKMARK);
-        }
-    }
-
     private void checkPlaceExists(LocationType locationType, Long locationId) {
         if (LocationType.BUILDING.equals(locationType) && !buildingRepository.existsById(locationId)) {
             throw new GlobalException(NOT_FOUND_BUILDING);

--- a/src/test/java/devkor/com/teamcback/TestTimer.java
+++ b/src/test/java/devkor/com/teamcback/TestTimer.java
@@ -1,0 +1,13 @@
+package devkor.com.teamcback;
+
+
+public class TestTimer {
+
+    public static void run(String label, Runnable testLogic) {
+        long start = System.currentTimeMillis();
+        testLogic.run();
+        long duration = System.currentTimeMillis() - start;
+        System.out.printf("⏱️ [%s] 실행 시간: %dms%n", label, duration);
+    }
+
+}

--- a/src/test/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,0 +1,222 @@
+package devkor.com.teamcback.domain.bookmark.repository;
+
+import devkor.com.teamcback.TestTimer;
+import devkor.com.teamcback.domain.bookmark.dto.request.CreateBookmarkReq;
+import devkor.com.teamcback.domain.bookmark.entity.Bookmark;
+import devkor.com.teamcback.domain.bookmark.entity.Category;
+import devkor.com.teamcback.domain.bookmark.entity.CategoryBookmark;
+import devkor.com.teamcback.domain.bookmark.entity.Color;
+import devkor.com.teamcback.domain.common.LocationType;
+import devkor.com.teamcback.domain.user.entity.Provider;
+import devkor.com.teamcback.domain.user.entity.Role;
+import devkor.com.teamcback.domain.user.entity.User;
+import devkor.com.teamcback.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookmarkRepositoryTest {
+    @Autowired
+    BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    CategoryBookmarkRepository categoryBookmarkRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EntityManager em;
+
+    Category targetCategory;
+    Bookmark targetBookmark;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(new User("user1", "email", Role.USER, Provider.KAKAO));
+        targetBookmark = bookmarkRepository.save(new Bookmark(new CreateBookmarkReq(new ArrayList<>(), LocationType.PLACE, 1L, "memo")));
+        targetCategory = categoryRepository.save(new Category("category1", Color.RED, user));
+
+        CategoryBookmark cb = new CategoryBookmark();
+        cb.setCategoryAndBookmark(targetCategory, targetBookmark);
+        categoryBookmarkRepository.save(cb);
+
+        for (int i = 0; i < 3; i++) {
+            Category category = categoryRepository.save(new Category("category1", Color.RED, user));
+            CategoryBookmark cb1 = new CategoryBookmark();
+            cb1.setCategoryAndBookmark(category, targetBookmark);
+            categoryBookmarkRepository.save(cb1);
+        }
+
+        for (int i = 0; i < 3; i++) {
+            Bookmark bookmark = bookmarkRepository.save(new Bookmark(new CreateBookmarkReq(new ArrayList<>(), LocationType.PLACE, (long)i+4, "memo")));
+            CategoryBookmark cb1 = new CategoryBookmark();
+            cb1.setCategoryAndBookmark(targetCategory, bookmark);
+            categoryBookmarkRepository.save(cb1);
+        }
+
+        for (int i = 0; i < 10000; i++) {
+            Category category = categoryRepository.save(new Category("category1", Color.RED, user));
+            Bookmark bookmark = bookmarkRepository.save(new Bookmark(new CreateBookmarkReq(new ArrayList<>(), LocationType.PLACE, (long)i + 100, "memo")));
+
+            CategoryBookmark cb1 = new CategoryBookmark();
+            cb1.setCategoryAndBookmark(category, bookmark);
+            categoryBookmarkRepository.save(cb1);
+        }
+
+        em.flush();
+        em.clear();
+    }
+
+//    @Test
+    @DisplayName("카테고리 북마크 확인")
+    void findByCategoryAndBookmark() {
+
+        TestTimer.run("findByCategoryAndBookmark", () -> {
+            categoryBookmarkRepository.findByCategoryAndBookmark(targetCategory, targetBookmark);
+        });
+
+        // 36ms
+    }
+
+//    @Test
+    @DisplayName("카테고리 북마크 확인 - 인덱스(카테고리, 북마크) 추가")
+    void findByCategoryAndBookmarkWithIndex1() {
+        em.createNativeQuery("CREATE INDEX idx1 ON tb_category_bookmark (category_id, bookmark_id)").executeUpdate();
+
+        em.flush();
+        em.clear();
+
+        TestTimer.run("findByCategoryAndBookmarkWithIndex1", () -> {
+            categoryBookmarkRepository.findByCategoryAndBookmark(targetCategory, targetBookmark);
+        });
+
+        // 399ms - 59ms
+    }
+
+//    @Test
+    @DisplayName("카테고리 북마크 확인 - 인덱스(카테고리), 인덱스(북마크) 추가")
+    void findByCategoryAndBookmarkWithIndex2() {
+        em.createNativeQuery("CREATE INDEX idx1 ON tb_category_bookmark (category_id)").executeUpdate();
+        em.createNativeQuery("CREATE INDEX idx2 ON tb_category_bookmark (bookmark_id)").executeUpdate();
+
+        em.flush();
+        em.clear();
+
+        TestTimer.run("findByCategoryAndBookmarkWithIndex2", () -> {
+            categoryBookmarkRepository.findByCategoryAndBookmark(targetCategory, targetBookmark);
+        });
+
+        // 407ms - 45ms
+    }
+
+//    @Test
+    @DisplayName("북마크를 카테고리와 장소로 확인")
+    void findByCategoryAndLocationTypeAndLocationId() {
+        TestTimer.run("findByCategoryAndLocationTypeAndLocationId", () -> {
+            bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(targetBookmark.getLocationId(), targetBookmark.getLocationType(), targetCategory);
+        });
+
+        // 43ms
+    }
+
+//    @Test
+    @DisplayName("북마크를 카테고리와 장소로 확인 - 북마크 인덱스(장소id, 장소type) 추가")
+    void findByCategoryAndLocationTypeAndLocationIdWithIndex1() {
+        em.createNativeQuery("CREATE INDEX idx1 ON tb_bookmark (locationId, locationType)").executeUpdate();
+
+        em.flush();
+        em.clear();
+
+        TestTimer.run("findByCategoryAndLocationTypeAndLocationIdWithIndex1", () -> {
+            bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(targetBookmark.getLocationId(), targetBookmark.getLocationType(), targetCategory);
+        });
+
+        // 355ms - 72ms
+    }
+
+//    @Test
+    @DisplayName("북마크를 카테고리와 장소로 확인 - 북마크 인덱스(장소id), 인덱스(장소type) 추가 -> 현재 방식")
+    void findByCategoryAndLocationTypeAndLocationIdWithIndex2() {
+        em.createNativeQuery("CREATE INDEX idx1 ON tb_bookmark (locationId)").executeUpdate();
+        em.createNativeQuery("CREATE INDEX idx2 ON tb_bookmark (locationType)").executeUpdate();
+
+        em.flush();
+        em.clear();
+
+        TestTimer.run("findByCategoryAndLocationTypeAndLocationIdWithIndex1", () -> {
+            bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_Category(targetBookmark.getLocationId(), targetBookmark.getLocationType(), targetCategory);
+        });
+
+        // 409ms - 48ms
+    }
+
+//    @Test
+    @DisplayName("북마크 조회")
+    void findBookmark() {
+
+        TestTimer.run("findBookmark", () -> {
+            bookmarkRepository.findById(1L);
+        });
+
+    }
+
+//    @Test
+    @DisplayName("카테고리 조회")
+    void findCategory() {
+
+        TestTimer.run("findCategory", () -> {
+            categoryRepository.findById(1L);
+        });
+
+    }
+
+//    @Test
+    @DisplayName("카테고리에 있는 북마크 리스트 조회")
+    void findCategoryListByBookmark() {
+
+        TestTimer.run("findCategoryListByBookmark", () -> {
+            bookmarkRepository.findAllByCategoryBookmarkList_CategoryId(targetCategory.getId());
+        });
+
+        // 225ms - 88ms
+        // left join category_bookmark left join category
+
+        // -> @Qeury로 수정 후
+
+        // 172ms - 57ms
+        // join
+    }
+
+//    @Test
+    @DisplayName("카테고리 리스트에 속하는 장소로 북마크 조회")
+    void findBookmarkByCategoryListAndLocation() {
+
+        List<Category> categoryList = new ArrayList<>();
+        categoryList.add(targetCategory);
+
+        TestTimer.run("findBookmarkByCategoryListAndLocation", () -> {
+            bookmarkRepository.findByLocationIdAndLocationTypeAndCategoryBookmarkList_CategoryIn(targetBookmark.getLocationId(), targetBookmark.getLocationType(), categoryList);
+        });
+
+        // 157ms - 53ms
+        // left join category_bookmark left join category
+
+        // 153ms - 52ms
+        // join category_bookmark
+    }
+}


### PR DESCRIPTION
## 개요
즐겨찾기 관련 repository를 수정했습니다.

## 작업사항
- 다대다 관계에서 left join이 2번 발생해서 sql 작성해서 join이 1번만 발생하도록 수정했습니다.
- 그 외에 사용하지 않는 코드 삭제하고 쿼리 검토 겸 테스트 코드를 작성했었는데 주석처리했습니다!

## 관련 이슈
- 즐겨찾기 관련 기능이 아직 프론트에 적용되지 않아서 데이터가 많지 않은데, 많아지면 이후에 인덱스도 적용해보고 싶습니다. 그래서 테스트코드를 한 번 작성해보았는데 무시하셔도 괜찮습니다!
