### PR TITLE
Feat: cloudwatch api별 요청 횟수 지표 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,9 @@ dependencies {
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // prometheus
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    // cloudwatch
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
+    implementation 'software.amazon.awssdk:cloudwatch'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/devkor/com/teamcback/global/config/WebConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package devkor.com.teamcback.global.config;
+
+import devkor.com.teamcback.infra.cloudwatch.MetricsInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    private MetricsInterceptor metricsInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(metricsInterceptor);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/CloudWatchConfig.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/CloudWatchConfig.java
@@ -1,0 +1,19 @@
+package devkor.com.teamcback.infra.cloudwatch;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+@Configuration
+public class CloudWatchConfig {
+
+    @Bean
+    public CloudWatchAsyncClient cloudWatchAsyncClient() {
+        return CloudWatchAsyncClient
+                .builder()
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}
+

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
@@ -40,7 +40,8 @@ public class MetricsInterceptor implements HandlerInterceptor {
                 "/api/search/buildings",
                 "/api/search/buildings/{buildingId}",
                 "/api/search/buildings/{buildingId}/facilities",
-                "/api/search/facilities"
+                "/api/search/facilities",
+                "/api/search/place/{placeId}"
         ).contains(uri);
     }
 }

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
@@ -1,0 +1,48 @@
+package devkor.com.teamcback.infra.cloudwatch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MetricsInterceptor implements HandlerInterceptor {
+
+    private final MetricsService metricsService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if(handler instanceof HandlerMethod) {
+            String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE);
+            if(shouldTrack(pattern)) {
+                metricsService.recordApiRequest(pattern);
+            }
+            return true;
+        }
+        return true;
+    }
+
+    private boolean shouldTrack(String uri) {
+        return List.of(
+                "/api/bookmarks",
+                "/api/categories",
+                "/api/routes",
+                "/api/users/login",
+                "/api/users/login/release",
+                "/api/users/mypage",
+                "/api/search",
+                "/api/search/buildings",
+                "/api/search/buildings/{buildingId}",
+                "/api/search/buildings/{buildingId}/facilities",
+                "/api/search/facilities"
+        ).contains(uri);
+    }
+}
+
+

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsInterceptor.java
@@ -19,7 +19,7 @@ public class MetricsInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         if(handler instanceof HandlerMethod) {
-            String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE);
+            String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
             if(shouldTrack(pattern)) {
                 metricsService.recordApiRequest(pattern);
             }

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
@@ -21,18 +21,20 @@ public class MetricsService {
     @Value("${metrics.environment}")
     private String environment;
 
+    private final String TARGET = "dev"; // 테스트 후 prod로 변경
+
     private final CloudWatchAsyncClient cloudWatchAsyncClient;
     private final Map<String, AtomicInteger> uriCountMap = new ConcurrentHashMap<>();
 
     public void recordApiRequest(String uri) {
-        if("prod".equalsIgnoreCase(environment)) {
+        if(TARGET.equalsIgnoreCase(environment)) {
             uriCountMap.computeIfAbsent(uri, k -> new AtomicInteger(0)).incrementAndGet();
         }
     }
 
     @Scheduled(fixedRate = 60_000)
     public void sendMetricsToCloudWatch() {
-        if ("prod".equalsIgnoreCase(environment)) {
+        if (TARGET.equalsIgnoreCase(environment)) {
             List<MetricDatum> metricDataList = uriCountMap.entrySet().stream()
                     .map(entry -> {
                         String uri = entry.getKey();

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
@@ -1,0 +1,65 @@
+package devkor.com.teamcback.infra.cloudwatch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.*;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+public class MetricsService {
+    private final CloudWatchAsyncClient cloudWatchAsyncClient;
+    private final Map<String, AtomicInteger> uriCountMap = new ConcurrentHashMap<>();
+
+    public void recordApiRequest(String uri) {
+
+        uriCountMap.computeIfAbsent(uri, k -> new AtomicInteger(0)).incrementAndGet();
+
+    }
+
+    @Scheduled(fixedRate = 60_000)
+    public void sendMetricsToCloudWatch() {
+        List<MetricDatum> metricDataList = uriCountMap.entrySet().stream()
+                        .map(entry -> {
+                            String uri = entry.getKey();
+                            int count = entry.getValue().getAndSet(0);
+
+                            if(count > 0) {
+                                return MetricDatum.builder()
+                                        .metricName("ApiRequestCount")
+                                        .dimensions(
+                                                Dimension.builder().name("URI").value(uri).build()
+                                        )
+                                        .unit(StandardUnit.COUNT)
+                                        .value((double) count)
+                                        .timestamp(Instant.now())
+                                        .build();
+                            }
+                            return null;
+                        })
+                .filter(Objects::nonNull)
+                .toList();
+
+        if(!metricDataList.isEmpty()) {
+            PutMetricDataRequest request = PutMetricDataRequest.builder()
+                    .namespace("MyApp/Metrics")
+                    .metricData(metricDataList)
+                    .build();
+
+            cloudWatchAsyncClient.putMetricData(request).whenComplete((resp, err) -> {
+                if (err != null) {
+                    System.err.println("Failed to send metric: " + err.getMessage());
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.infra.cloudwatch;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
@@ -17,49 +18,54 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Service
 @RequiredArgsConstructor
 public class MetricsService {
+    @Value("${metrics.environment}")
+    private String environment;
+
     private final CloudWatchAsyncClient cloudWatchAsyncClient;
     private final Map<String, AtomicInteger> uriCountMap = new ConcurrentHashMap<>();
 
     public void recordApiRequest(String uri) {
-
-        uriCountMap.computeIfAbsent(uri, k -> new AtomicInteger(0)).incrementAndGet();
-
+        if("prod".equalsIgnoreCase(environment)) {
+            uriCountMap.computeIfAbsent(uri, k -> new AtomicInteger(0)).incrementAndGet();
+        }
     }
 
     @Scheduled(fixedRate = 60_000)
     public void sendMetricsToCloudWatch() {
-        List<MetricDatum> metricDataList = uriCountMap.entrySet().stream()
-                        .map(entry -> {
-                            String uri = entry.getKey();
-                            int count = entry.getValue().getAndSet(0);
+        if ("prod".equalsIgnoreCase(environment)) {
+            List<MetricDatum> metricDataList = uriCountMap.entrySet().stream()
+                    .map(entry -> {
+                        String uri = entry.getKey();
+                        int count = entry.getValue().getAndSet(0);
 
-                            if(count > 0) {
-                                return MetricDatum.builder()
-                                        .metricName("ApiRequestCount")
-                                        .dimensions(
-                                                Dimension.builder().name("URI").value(uri).build()
-                                        )
-                                        .unit(StandardUnit.COUNT)
-                                        .value((double) count)
-                                        .timestamp(Instant.now())
-                                        .build();
-                            }
-                            return null;
-                        })
-                .filter(Objects::nonNull)
-                .toList();
+                        if (count > 0) {
+                            return MetricDatum.builder()
+                                    .metricName("ApiRequestCount")
+                                    .dimensions(
+                                            Dimension.builder().name("URI").value(uri).build()
+                                    )
+                                    .unit(StandardUnit.COUNT)
+                                    .value((double) count)
+                                    .timestamp(Instant.now())
+                                    .build();
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .toList();
 
-        if(!metricDataList.isEmpty()) {
-            PutMetricDataRequest request = PutMetricDataRequest.builder()
-                    .namespace("MyApp/Metrics")
-                    .metricData(metricDataList)
-                    .build();
+            if (!metricDataList.isEmpty()) {
+                PutMetricDataRequest request = PutMetricDataRequest.builder()
+                        .namespace("Kodaero/Metrics")
+                        .metricData(metricDataList)
+                        .build();
 
-            cloudWatchAsyncClient.putMetricData(request).whenComplete((resp, err) -> {
-                if (err != null) {
-                    System.err.println("Failed to send metric: " + err.getMessage());
-                }
-            });
+                cloudWatchAsyncClient.putMetricData(request).whenComplete((resp, err) -> {
+                    if (err != null) {
+                        System.err.println("Failed to send metric: " + err.getMessage());
+                    }
+                });
+            }
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,15 +30,6 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD}
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: prometheus, health, info, metrics
-  prometheus:
-    metrics:
-      export:
-        enabled: true
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,3 +103,6 @@ date:
       end-point: ${HOLIDAY_API_END_POINT}
       encoded-key: ${HOLIDAY_API_ENCODED_KEY}
       decoded-key: ${HOLIDAY_API_DECODED_KEY}
+
+metrics:
+  environment: dev


### PR DESCRIPTION
## 개요
cloudwatch api별 요청 횟수 지표 추가

## 작업사항
- cloudwatch에 uri별 요청 횟수를 1분마다 전송하도록 설정 -> cloudwatch 대시보드에서 확인 가능
- 특정 서버에서만 보내기 위해 application.yml 값 추가
- 비용을 줄이기 위해 지표 uri을 제한(제 생각에 주요 uri를 적어봤는데 추가/삭제해도 좋은 uri 있으면 수정하셔도 됩니다!), uri 정규화 (building/123 -> building/{buildingId} 등)

## 관련 이슈
- 따로 프로메테우스, 그라파나 컨테이너를 띄우는 것보다 cloudwatch를 사용하는게 더 간단하고 비용도 줄일 수 있을 것 같아서 적용해보았습니다.
- 저도 처음 해보는 거라 한번 개발 서버에서 확인해보고 배포 서버로 수정해야 할 것 같아요!
