### PR TITLE
Fix: 배포 서버로 적용 변경

### DIFF
--- a/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
+++ b/src/main/java/devkor/com/teamcback/infra/cloudwatch/MetricsService.java
@@ -21,7 +21,7 @@ public class MetricsService {
     @Value("${metrics.environment}")
     private String environment;
 
-    private final String TARGET = "dev"; // 테스트 후 prod로 변경
+    private final String TARGET = "prod";
 
     private final CloudWatchAsyncClient cloudWatchAsyncClient;
     private final Map<String, AtomicInteger> uriCountMap = new ConcurrentHashMap<>();
@@ -35,6 +35,7 @@ public class MetricsService {
     @Scheduled(fixedRate = 60_000)
     public void sendMetricsToCloudWatch() {
         if (TARGET.equalsIgnoreCase(environment)) {
+            if(uriCountMap.isEmpty()) return;
             List<MetricDatum> metricDataList = uriCountMap.entrySet().stream()
                     .map(entry -> {
                         String uri = entry.getKey();


### PR DESCRIPTION
## 개요
개발 서버 테스트 후 배포 서버인 경우에만 metric을 보내도록 수정했습니다.

## 작업사항
- 적용 대상을 배포 서버로 변경
- 보낼 메트릭 없으면 객체 생성하지 않고 바로 return하도록 수정

## 관련 이슈
- 
