### PR TITLE
대동제 및 베리어프리 관련 엔티티 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/koyeon/entity/FreePub.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/entity/FreePub.java
@@ -5,6 +5,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 @Entity
 @Getter
 @Table(name = "tb_free_pub")
@@ -38,4 +42,17 @@ public class FreePub {
 
     @Column(nullable = false)
     private Double longitude;
+
+    @Column
+    private Date operatingDate;
+
+    @Column(length = 1500)
+    private String content;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @OneToMany(mappedBy = "freePub", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PubImage> images = new ArrayList<>();
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/entity/PubImage.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/entity/PubImage.java
@@ -1,0 +1,23 @@
+package devkor.com.teamcback.domain.koyeon.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tb_pub_image")
+@NoArgsConstructor
+public class PubImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "freePub_id")
+    private FreePub freePub;
+
+}

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/entity/Type.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/entity/Type.java
@@ -1,0 +1,5 @@
+package devkor.com.teamcback.domain.koyeon.entity;
+
+public enum Type {
+    PUB, BOOTH;
+}

--- a/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceType.java
+++ b/src/main/java/devkor/com/teamcback/domain/place/entity/PlaceType.java
@@ -34,7 +34,8 @@ public enum PlaceType {
     BOOK_RETURN_MACHINE("도서반납기", new String[]{"책반납기계", "도서반납기계"}),
     TUMBLER_WASHER("텀블러세척기", new String[]{}),
     ONESTOP_AUTO_MACHINE("원스탑무인발급기", new String[]{"원스톱무인발급기", "증명서", "ONE-STOP", "ONESTOP"}),
-    HEALTH_OFFICE("건강센터", new String[]{"약받는곳", "보건실", "양호실", "응급약", "약받을수있는", "다쳤을때"});
+    HEALTH_OFFICE("건강센터", new String[]{"약받는곳", "보건실", "양호실", "응급약", "약받을수있는", "다쳤을때"}),
+    DISABLED_PARKING("장애인주차장", new String[] {"장애인주차장", "베리어프리", "휠체어주차장"});
 
     private final String name;
     private final String[] nickname;


### PR DESCRIPTION
## 개요
대동제 및 베리어프리 관련 엔티티 수정

## 작업사항
- 대동제를 위한 주점 엔티티 필드 추가 (내용, 사진, 날짜, 종류)
- 베리어프리 관련 장소 타입 추가: 장애인 주차장 

## 관련 이슈
- 장애인 주차장을 장소로 저장하고 노드랑 연관관계를 맺었는데 이 방식 괜찮을까요? 추가적으로 여은님이 장애인 주차장 태그 검색하는 기능 추가해주시면 감사하겠습니다!
