### PR TITLE
Fix: 검색 시 즐겨찾기 여부 반환 오류 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
+++ b/src/main/java/devkor/com/teamcback/domain/search/contoller/SearchController.java
@@ -188,7 +188,7 @@ public class SearchController {
     })
     @GetMapping("/buildings/{buildingId}")
     public CommonResponse<SearchBuildingDetailRes> searchBuildingDetail(
-        @Parameter(description = "사용자정보", required = false)
+        @Parameter(description = "사용자정보")
         @AuthenticationPrincipal UserDetailsImpl userDetail,
         @Parameter(name = "buildingId", description = "건물 id", example = "1", required = true)
         @PathVariable Long buildingId) {
@@ -209,7 +209,7 @@ public class SearchController {
     })
     @GetMapping("/place/{placeId}")
     public CommonResponse<SearchPlaceDetailRes> searchPlaceDetail(
-        @Parameter(description = "사용자정보", required = false)
+        @Parameter(description = "사용자정보")
         @AuthenticationPrincipal UserDetailsImpl userDetail,
         @Parameter(name = "placeId", description = "placeId", example = "1", required = true)
         @PathVariable Long placeId) {

--- a/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
@@ -34,7 +34,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             new AntPathRequestMatcher("/api/migration"),
             new AntPathRequestMatcher("/api/koyeon/**"),
             new AntPathRequestMatcher("/api/routes/**"),
-            new AntPathRequestMatcher("/api/search/**", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search/buildings", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search/buildings/**/facilities/**", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search/buildings/**/floor/**", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search/facilities", HttpMethod.GET.name()),
+            new AntPathRequestMatcher("/api/search/place/**/mask", HttpMethod.GET.name()),
             new AntPathRequestMatcher("/api/users/login/**"));
 
     private final JwtUtil jwtUtil;


### PR DESCRIPTION
## 개요
건물, 장소 검색 시 즐겨찾기 여부 반환 오류 수정

## 작업사항
- 예전에 토큰이 이상해도 오류나지 않도록 search api를 화이트리스트에 등록했었는데 그것 때문에 사용자 정보가 안들어가서 오류가 났네요.. 그래서 장소, 건물 검색은 제외하고 화이트리스트를 수정했습니다.

## 관련 이슈
- 
