### PR TITLE
Feat: 파일 요청 크기 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
         mode: always
         encoding: UTF-8
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 50MB
+
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## 개요
파일 요청 크기 설정

## 작업사항
- 스프링: 파일당 5MB, 전체 50MB 설정(코드에서)
- nginx: 전체 요청 50MB 설정(서버에서)

## 관련 이슈
- 
