### PR TITLE
Feat: 투표 관리용 api

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/vote/controller/AdminVoteController.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/controller/AdminVoteController.java
@@ -1,6 +1,8 @@
 package devkor.com.teamcback.domain.vote.controller;
 
 import devkor.com.teamcback.domain.vote.dto.response.ChangeVoteStatusRes;
+import devkor.com.teamcback.domain.vote.dto.response.GetVoteRes;
+import devkor.com.teamcback.domain.vote.entity.VoteStatus;
 import devkor.com.teamcback.domain.vote.service.VoteService;
 import devkor.com.teamcback.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +12,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,10 +31,33 @@ public class AdminVoteController {
             @ApiResponse(responseCode = "404", description = "Not Found",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @GetMapping("/{voteId}")
+    @PatchMapping("/{voteId}")
     public CommonResponse<ChangeVoteStatusRes> changeVoteStatus(
             @Parameter(description = "투표 ID", example = "1")
-            @PathVariable(name = "voteId") Long voteId) {
-        return CommonResponse.success(voteService.changeVoteStatus(voteId));
+            @PathVariable(name = "voteId") Long voteId,
+            @Parameter(description = "투표 상태", example = "REFLECTED")
+            @RequestParam(name = "status") VoteStatus status) {
+        return CommonResponse.success(voteService.changeVoteStatus(voteId, status));
+    }
+
+    /**
+     * 투표 조회
+     */
+    @Operation(summary = "투표 조회", description = "투표 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정상 처리 되었습니다."),
+            @ApiResponse(responseCode = "404", description = "Not Found",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @GetMapping()
+    public CommonResponse<List<GetVoteRes>> getVoteList(
+            @Parameter(description = "투표 상태", example = "REFLECTED")
+            @RequestParam(name = "status", required = false) VoteStatus status,
+            @Parameter(description = "마지막 조회 투표 ID", example = "0")
+            @RequestParam(name = "lastVoteId", defaultValue = "0", required = false) Long lastVoteId,
+            @Parameter(description = "조회 size", example = "20")
+            @RequestParam(name = "size", defaultValue = "20", required = false) int size
+            ) {
+        return CommonResponse.success(voteService.getVoteList(status, lastVoteId, size));
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/entity/Vote.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/entity/Vote.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import static devkor.com.teamcback.domain.vote.entity.VoteStatus.CLOSED;
-import static devkor.com.teamcback.domain.vote.entity.VoteStatus.OPEN;
 import static devkor.com.teamcback.global.response.ResultCode.CLOSED_VOTE;
 
 @Entity
@@ -35,8 +34,7 @@ public class Vote extends BaseEntity {
         if(this.status == CLOSED) throw new GlobalException(CLOSED_VOTE);
     }
 
-    public void changeStatus() {
-        if(this.status == CLOSED) this.status = OPEN;
-        else this.status = CLOSED;
+    public void changeStatus(VoteStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/entity/VoteStatus.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/entity/VoteStatus.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum VoteStatus {
     OPEN("진행 중"),
-    CLOSED("종료");
+    CLOSED("종료"),
+    REFLECTED("결과 반영됨");
 
     private final String name;
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepository.java
@@ -13,4 +13,6 @@ public interface CustomVoteRepository {
     List<Vote> getVoteByStatusWithPage(VoteStatus status, Long voteTopicId, int size);
 
     List<GetVoteOptionRes> getVoteOptionByVoteId(Long voteId);
+
+    List<GetVoteOptionRes> getVoteOptionByVoteIdOrderByCount(Long voteId);
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepository.java
@@ -2,9 +2,15 @@ package devkor.com.teamcback.domain.vote.repository;
 
 
 import devkor.com.teamcback.domain.vote.dto.response.GetVoteOptionRes;
+import devkor.com.teamcback.domain.vote.entity.Vote;
+import devkor.com.teamcback.domain.vote.entity.VoteStatus;
 
 import java.util.List;
 
 public interface CustomVoteRepository {
     List<GetVoteOptionRes> getVoteOptionsByPlaceByVoteTopicIdAndPlaceId(Long voteTopicId, Long placeId);
+
+    List<Vote> getVoteByStatusWithPage(VoteStatus status, Long voteTopicId, int size);
+
+    List<GetVoteOptionRes> getVoteOptionByVoteId(Long voteId);
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepositoryImpl.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepositoryImpl.java
@@ -1,13 +1,20 @@
 package devkor.com.teamcback.domain.vote.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import static devkor.com.teamcback.domain.place.entity.QPlace.place;
 import static devkor.com.teamcback.domain.vote.entity.QVoteOption.voteOption;
 import static devkor.com.teamcback.domain.vote.entity.QVoteRecord.voteRecord;
 import static devkor.com.teamcback.domain.vote.entity.QVote.vote;
 
+import devkor.com.teamcback.domain.place.entity.Place;
+import devkor.com.teamcback.domain.place.entity.PlaceType;
 import devkor.com.teamcback.domain.vote.dto.response.GetVoteOptionRes;
 import devkor.com.teamcback.domain.vote.dto.response.QGetVoteOptionRes;
+import devkor.com.teamcback.domain.vote.entity.Vote;
+import devkor.com.teamcback.domain.vote.entity.VoteStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -44,5 +51,57 @@ public class CustomVoteRepositoryImpl implements CustomVoteRepository{
                         voteOption.id.asc()
                 )
                 .fetch();
+    }
+
+    @Override
+    public List<Vote> getVoteByStatusWithPage(VoteStatus status, Long lastVoteId, int size) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(gtVoteCursor(lastVoteId));
+
+        if (status != null) {
+            builder.and(vote.status.eq(status));
+        }
+
+        return jpaQueryFactory
+                .selectFrom(vote)
+                .where(
+                        gtVoteCursor(lastVoteId).and(builder)
+                )
+                .orderBy(
+                        vote.id.asc()
+                )
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<GetVoteOptionRes> getVoteOptionByVoteId(Long voteId) {
+        return jpaQueryFactory
+                .select(
+                        new QGetVoteOptionRes(
+                                voteOption.id,
+                                voteOption.optionText,
+                                voteRecord.id.count().intValue()
+                        )
+                )
+                .from(vote)
+                .join(voteOption)
+                .on(vote.voteTopicId.eq(voteOption.voteTopicId))
+                .leftJoin(voteRecord)
+                .on(voteRecord.voteId.eq(vote.id)
+                        .and(voteRecord.voteOptionId.eq(voteOption.id)))
+                .where(
+                        vote.id.eq(voteId)
+                )
+                .groupBy(voteOption.id, voteOption.optionText)
+                .orderBy(
+                        voteOption.id.asc()
+                )
+                .fetch();
+    }
+
+    private BooleanExpression gtVoteCursor(Long lastVoteId) {
+        if (lastVoteId== null) return null;
+        return vote.id.gt(lastVoteId);
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepositoryImpl.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/repository/CustomVoteRepositoryImpl.java
@@ -100,6 +100,32 @@ public class CustomVoteRepositoryImpl implements CustomVoteRepository{
                 .fetch();
     }
 
+    @Override
+    public List<GetVoteOptionRes> getVoteOptionByVoteIdOrderByCount(Long voteId) {
+        return jpaQueryFactory
+                .select(
+                        new QGetVoteOptionRes(
+                                voteOption.id,
+                                voteOption.optionText,
+                                voteRecord.id.count().intValue()
+                        )
+                )
+                .from(vote)
+                .join(voteOption)
+                .on(vote.voteTopicId.eq(voteOption.voteTopicId))
+                .leftJoin(voteRecord)
+                .on(voteRecord.voteId.eq(vote.id)
+                        .and(voteRecord.voteOptionId.eq(voteOption.id)))
+                .where(
+                        vote.id.eq(voteId)
+                )
+                .groupBy(voteOption.id, voteOption.optionText)
+                .orderBy(
+                        voteRecord.id.count().intValue().asc()
+                )
+                .fetch();
+    }
+
     private BooleanExpression gtVoteCursor(Long lastVoteId) {
         if (lastVoteId== null) return null;
         return vote.id.gt(lastVoteId);

--- a/src/main/java/devkor/com/teamcback/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/repository/VoteRepository.java
@@ -1,10 +1,17 @@
 package devkor.com.teamcback.domain.vote.repository;
 
 import devkor.com.teamcback.domain.vote.entity.Vote;
+import devkor.com.teamcback.domain.vote.entity.VoteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
     Optional<Vote> findByVoteTopicIdAndPlaceId(Long voteTopicId, Long placeId);
+
+    @Query("SELECT v FROM Vote v WHERE v.status IS NULL OR v.status = :status")
+    List<Vote> findAllByStatus(@Param("status")VoteStatus status);
 }

--- a/src/main/java/devkor/com/teamcback/domain/vote/service/VoteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/service/VoteService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
+import static devkor.com.teamcback.domain.vote.entity.VoteStatus.CLOSED;
 import static devkor.com.teamcback.global.response.ResultCode.*;
 
 @Service
@@ -58,7 +59,7 @@ public class VoteService {
     /**
      * 투표 저장
      */
-    @UpdateScore(addScore = 2)
+    @UpdateScore(addScore = 3)
     @Transactional
     public SaveVoteRecordRes saveVoteRecord(Long userId, SaveVoteRecordReq req) {
         if(userId == null) throw new GlobalException(FORBIDDEN);
@@ -86,6 +87,12 @@ public class VoteService {
         else { // 같은 걸 투표한 경우 -> 토글로 취소됨
             voteRecord.setVoteOptionId(null); // 기존 투표 옵션을 null로 설정 (기록 남기기)
         }
+
+        // 투표 상태 변경
+        List<GetVoteOptionRes> voteOptionList = voteOptionRepository.getVoteOptionByVoteIdOrderByCount(vote.getId()); // 투표 항목, 현황
+        int min = voteOptionList.get(0).getVoteCount();
+        int max = voteOptionList.get(voteOptionList.size() - 1).getVoteCount();
+        if(max - min >= 30) vote.changeStatus(CLOSED);
 
         return new SaveVoteRecordRes();
     }

--- a/src/main/java/devkor/com/teamcback/domain/vote/service/VoteService.java
+++ b/src/main/java/devkor/com/teamcback/domain/vote/service/VoteService.java
@@ -91,14 +91,39 @@ public class VoteService {
     }
 
     /**
-     * 투표 상태 변경(토글)
+     * 투표 리스트 조회
      */
-    public ChangeVoteStatusRes changeVoteStatus(Long voteId) {
+    @Transactional(readOnly = true)
+    public List<GetVoteRes> getVoteList(VoteStatus status, Long lastVoteId, int size) {
+        List<GetVoteRes> resList = new ArrayList<>();
+
+        List<Vote> voteList = voteOptionRepository.getVoteByStatusWithPage(status, lastVoteId, size);
+
+        for(Vote vote : voteList) {
+            // 투표 주제
+            VoteTopic voteTopic = findVoteTopic(vote.getVoteTopicId());
+
+            // 투표 장소
+            Place place = findPlace(vote.getPlaceId());
+
+            // 투표 항목, 현황
+            List<GetVoteOptionRes> voteOptionList = voteOptionRepository.getVoteOptionByVoteId(vote.getId());
+
+            resList.add(new GetVoteRes(vote.getId(), vote.getStatus().toString(), voteTopic.getId(), voteTopic.getTopic(), place.getId(), place.getName(), voteOptionList));
+        }
+
+        return resList;
+    }
+
+    /**
+     * 투표 상태 변경
+     */
+    public ChangeVoteStatusRes changeVoteStatus(Long voteId, VoteStatus status) {
         // 투표
         Vote vote = findVote(voteId);
 
         // 상태 변경
-        vote.changeStatus();
+        vote.changeStatus(status);
 
         return new ChangeVoteStatusRes();
     }


### PR DESCRIPTION
## 개요
투표 관리를 위한 api 추가 및 코드 수정했습니다.

## 작업사항
- 투표 관리자 api 추가: 투표 상태 변경, 상태별 리스트 조회
- 투표 상태 변경 로직 추가(30표 이상 차이나면 종료) : CLOSED 한 후에 닫힌 투표 목록 조회해서, 결과 반영하고 REFLECTED로 상태 변경하는 걸 생각했습니다. 매일 돌아가기에는 장소가 너무 많은 것 같아서 투표 저장 api에 추가해봤습니다...!
- 투표 포인트 3점으로 수정

## 관련 이슈
- 
