### PR TITLE
Fix: 무료주점 DTO 수정

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
@@ -26,9 +26,9 @@ public class SearchFreePubRes {
     @Schema(description = "주점 주소", example = "서울특별시 성북구 5가")
     private String address;
     @Schema(description = "태그에 해당하는 음식 리스트", example = "[\"떡볶이\"]")
-    private List<String> menus;
+    private List<String> filteredMenus;
 
-    public SearchFreePubRes(FreePub pub, List<String> menus) {
+    public SearchFreePubRes(FreePub pub, List<String> filteredMenus) {
         this.id = pub.getId();
         this.name = pub.getName();
         this.sponsor = pub.getSponsor();
@@ -37,6 +37,6 @@ public class SearchFreePubRes {
         this.longitude = pub.getLongitude();
         if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
         this.address = pub.getAddress();
-        this.menus = menus;
+        this.filteredMenus = filteredMenus;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/dto/response/SearchFreePubRes.java
@@ -2,10 +2,9 @@ package devkor.com.teamcback.domain.koyeon.dto.response;
 
 import devkor.com.teamcback.domain.koyeon.entity.FreePub;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Schema(description = "주점 정보")
 @Getter
@@ -24,10 +23,12 @@ public class SearchFreePubRes {
     private Double latitude;
     @Schema(description = "노드 ID", example = "1")
     private Long nodeId = null;
+    @Schema(description = "주점 주소", example = "서울특별시 성북구 5가")
+    private String address;
     @Schema(description = "태그에 해당하는 음식 리스트", example = "[\"떡볶이\"]")
-    private List<String> filteredMenus = new ArrayList<>();
+    private List<String> menus;
 
-    public SearchFreePubRes(FreePub pub) {
+    public SearchFreePubRes(FreePub pub, List<String> menus) {
         this.id = pub.getId();
         this.name = pub.getName();
         this.sponsor = pub.getSponsor();
@@ -35,16 +36,7 @@ public class SearchFreePubRes {
         this.latitude = pub.getLatitude();
         this.longitude = pub.getLongitude();
         if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
-    }
-
-    public SearchFreePubRes(FreePub pub, List<String> filteredMenus) {
-        this.id = pub.getId();
-        this.name = pub.getName();
-        this.sponsor = pub.getSponsor();
-        this.operatingTime = pub.getOperatingTime();
-        this.latitude = pub.getLatitude();
-        this.longitude = pub.getLongitude();
-        if(pub.getNode() != null) this.nodeId = pub.getNode().getId();
-        this.filteredMenus = filteredMenus;
+        this.address = pub.getAddress();
+        this.menus = menus;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/koyeon/service/KoyeonService.java
+++ b/src/main/java/devkor/com/teamcback/domain/koyeon/service/KoyeonService.java
@@ -1,10 +1,10 @@
 package devkor.com.teamcback.domain.koyeon.service;
 
-import devkor.com.teamcback.domain.schoolcalendar.entity.SchoolCalendar;
-import devkor.com.teamcback.domain.schoolcalendar.repository.SchoolCalendarRepository;
 import devkor.com.teamcback.domain.koyeon.dto.response.*;
 import devkor.com.teamcback.domain.koyeon.entity.*;
 import devkor.com.teamcback.domain.koyeon.repository.*;
+import devkor.com.teamcback.domain.schoolcalendar.entity.SchoolCalendar;
+import devkor.com.teamcback.domain.schoolcalendar.repository.SchoolCalendarRepository;
 import devkor.com.teamcback.global.exception.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,10 +72,12 @@ public class KoyeonService {
             return new SearchFreePubListRes(pubResList);
         }
 
-        return new SearchFreePubListRes(freePubRepository.findAll()
-            .stream()
-            .map(SearchFreePubRes::new)
-            .toList());
+        List<FreePub> pubList = freePubRepository.findAll();
+        List<SearchFreePubRes> pubResList = new ArrayList<>();
+        for (FreePub pub : pubList) {
+            pubResList.add(new SearchFreePubRes(pub, menuRepository.findByFreePub(pub).stream().map(Menu::getName).toList()));
+        }
+        return new SearchFreePubListRes(pubResList);
     }
 
     /**


### PR DESCRIPTION
## 개요
pub 정보 DTO 수정

## 작업사항
- 무료 주점 리스트 반환 시 menu/주소를 함께 반환하도록 수정했습니다.

``` json
      {
        "menus": [
          "제육볶음",
          "전",
          "오뎅탕"
        ],
        "id": 48,
        "name": "왕빈대떡삼파전",
        "sponsor": "뉴욕 교우회",
        "operatingTime": null,
        "longitude": 127.0298492,
        "latitude": 37.5858241,
        "nodeId": 25213,
        "address": "서울특별시 성북구 고려대로26길 8"
      },
```
## 관련 이슈
- 
