### PR TITLE
Feat/push installation api

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/notification/controller/PushInstallationController.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/controller/PushInstallationController.java
@@ -1,0 +1,125 @@
+package devkor.com.teamcback.domain.notification.controller;
+
+
+import devkor.com.teamcback.domain.notification.dto.request.PushInstallationRegisterReq;
+import devkor.com.teamcback.domain.notification.service.PushInstallationService;
+import devkor.com.teamcback.global.response.CommonResponse;
+import devkor.com.teamcback.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "푸시 알림 설치 관리",
+        description = "로그인 사용자의 Expo Push installation 등록, 갱신 및 비활성화 API"
+)
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications/installations")
+public class PushInstallationController {
+
+    private final PushInstallationService pushInstallationService;
+
+    @Operation(
+            summary = "푸시 알림 installation 등록 및 갱신",
+            description = """
+                    현재 로그인 사용자의 Expo Push installation을 등록합니다.
+                    동일한 installationId로 다시 요청하면 새 행을 생성하지 않고
+                    기존 installation의 토큰, 사용자 및 앱 환경 정보를 갱신합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 또는 갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    @PutMapping("/{installationId}")
+    public ResponseEntity<CommonResponse<Void>> register(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetail,
+
+            @Parameter(
+                    description = "앱 설치를 식별하는 고유 ID",
+                    example = "11111111-2222-4333-8444-555555555555",
+                    required = true
+            )
+            @PathVariable
+            @NotBlank
+            @Size(max = 64)
+            String installationId,
+
+            @Valid
+            @RequestBody
+            PushInstallationRegisterReq request
+    ) {
+        Long userId = userDetail.getUser().getUserId();
+
+        pushInstallationService.register(
+                userId,
+                installationId,
+                request.expoPushToken(),
+                request.appVariant()
+        );
+
+        return ResponseEntity.ok(CommonResponse.success());
+    }
+
+    @Operation(
+            summary = "푸시 알림 installation 비활성화",
+            description = """
+                    현재 로그인 사용자가 소유한 installation을 비활성화합니다.
+                    대상이 없거나 이미 비활성화된 경우에도 성공으로 처리합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비활성화 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    @DeleteMapping("/{installationId}")
+    public ResponseEntity<CommonResponse<Void>> deactivate(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetail,
+
+            @Parameter(
+                    description = "비활성화할 앱 설치 식별자",
+                    example = "11111111-2222-4333-8444-555555555555",
+                    required = true
+            )
+            @PathVariable
+            @NotBlank
+            @Size(max = 64)
+            String installationId
+    ) {
+        Long userId = userDetail.getUser().getUserId();
+
+        pushInstallationService.deactivate(
+                userId,
+                installationId
+        );
+
+        return ResponseEntity.ok(CommonResponse.success());
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/request/PushInstallationRegisterReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/request/PushInstallationRegisterReq.java
@@ -1,0 +1,33 @@
+package devkor.com.teamcback.domain.notification.dto.request;
+
+import devkor.com.teamcback.domain.notification.entity.AppVariant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Expo Push installation 등록 요청")
+public record PushInstallationRegisterReq(
+
+        @Schema(description = "요청 스키마 버전", example = "1", allowableValues = {"1"})
+        @NotNull
+        @Min(1)
+        @Max(1)
+        Integer schemaVersion,
+
+        @Schema(description = "Expo에서 발급된 Push Token", example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]")
+        @NotBlank
+        String expoPushToken,
+
+        @Schema(description = "토큰이 발급된 앱 빌드 환경", example = "dev",
+                allowableValues = {
+                        "dev",
+                        "preview",
+                        "production"
+                }
+        )
+        @NotNull
+        AppVariant appVariant
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/AppVariant.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/AppVariant.java
@@ -1,0 +1,29 @@
+package devkor.com.teamcback.domain.notification.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum AppVariant {
+
+    DEV,
+    PREVIEW,
+    PRODUCTION;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AppVariant from(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return AppVariant.valueOf(
+                value.trim().toUpperCase(Locale.ROOT)
+        );
+    }
+
+    @JsonValue
+    public String toValue() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushInstallation.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushInstallation.java
@@ -1,0 +1,93 @@
+package devkor.com.teamcback.domain.notification.entity;
+
+import devkor.com.teamcback.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "tb_push_installation",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_push_installation_installation_id",
+                        columnNames = "installation_id"
+                ),
+                @UniqueConstraint(
+                        name = "uk_push_installation_expo_push_token",
+                        columnNames = "expo_push_token"
+                )
+        },
+        indexes = {
+                @Index(
+                        name = "idx_push_installation_user_variant_active",
+                        columnList = "user_id, app_variant, active"
+                )
+        }
+)
+@NoArgsConstructor
+@Getter
+public class PushInstallation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "push_installation_id")
+    private Long pushInstallationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "installation_id", nullable = false, length = 64)
+    private String installationId;
+
+    @Column(name = "expo_push_token", nullable = false, length = 255)
+    private String expoPushToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "app_variant", nullable = false, length = 20)
+    private AppVariant appVariant;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "deactivated_at")
+    private LocalDateTime deactivatedAt;
+
+    public PushInstallation(
+            Long userId,
+            String installationId,
+            String expoPushToken,
+            AppVariant appVariant
+    ) {
+        this.userId = userId;
+        this.installationId = installationId;
+        this.expoPushToken = expoPushToken;
+        this.appVariant = appVariant;
+        this.active = true;
+    }
+
+    public void register(
+            Long userId,
+            String installationId,
+            String expoPushToken,
+            AppVariant appVariant
+    ) {
+        this.userId = userId;
+        this.installationId = installationId;
+        this.expoPushToken = expoPushToken;
+        this.appVariant = appVariant;
+        this.active = true;
+        this.deactivatedAt = null;
+    }
+
+    public void deactivate(LocalDateTime now) {
+        if (!active) {
+            return;
+        }
+
+        this.active = false;
+        this.deactivatedAt = now;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
@@ -1,0 +1,27 @@
+package devkor.com.teamcback.domain.notification.repository;
+
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PushInstallationRepository extends JpaRepository<PushInstallation, Long> {
+
+    Optional<PushInstallation> findByInstallationId(
+            String installationId
+    );
+
+    Optional<PushInstallation> findByExpoPushToken(
+            String expoPushToken
+    );
+
+    Optional<PushInstallation> findByInstallationIdAndUserId(
+            String installationId,
+            Long userId
+    );
+
+    List<PushInstallation> findAllByUserIdAndActiveTrue(
+            Long userId
+    );
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushInstallationService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushInstallationService.java
@@ -1,0 +1,120 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.entity.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PushInstallationService {
+
+    private final PushInstallationRepository repository;
+    private final Clock clock;
+
+    @Transactional
+    public void register(
+            Long userId,
+            String installationId,
+            String expoPushToken,
+            AppVariant appVariant
+    ) {
+        Optional<PushInstallation> installationMatch = repository.findByInstallationId(installationId);
+
+        Optional<PushInstallation> tokenMatch = repository.findByExpoPushToken(expoPushToken);
+
+        if (installationMatch.isEmpty() && tokenMatch.isEmpty()) {
+            repository.save(
+                    new PushInstallation(
+                            userId,
+                            installationId,
+                            expoPushToken,
+                            appVariant
+                    )
+            );
+            return;
+        }
+
+        if (installationMatch.isPresent() && tokenMatch.isEmpty()) {
+            installationMatch.get().register(
+                    userId,
+                    installationId,
+                    expoPushToken,
+                    appVariant
+            );
+            return;
+        }
+
+        if (installationMatch.isEmpty()) {
+            tokenMatch.get().register(
+                    userId,
+                    installationId,
+                    expoPushToken,
+                    appVariant
+            );
+            return;
+        }
+
+        PushInstallation installationEntity = installationMatch.get();
+
+        PushInstallation tokenEntity = tokenMatch.get();
+
+        if (installationEntity == tokenEntity
+                || installationEntity.getPushInstallationId()
+                .equals(tokenEntity.getPushInstallationId())) {
+
+            installationEntity.register(
+                    userId,
+                    installationId,
+                    expoPushToken,
+                    appVariant
+            );
+            return;
+        }
+
+        repository.delete(tokenEntity);
+        repository.flush();
+
+        installationEntity.register(
+                userId,
+                installationId,
+                expoPushToken,
+                appVariant
+        );
+    }
+
+    @Transactional
+    public void deactivate(
+            Long userId,
+            String installationId
+    ) {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        repository.findByInstallationIdAndUserId(
+                        installationId,
+                        userId
+                )
+                .ifPresent(installation ->
+                        installation.deactivate(now)
+                );
+    }
+
+    @Transactional
+    public void deactivateAll(
+            Long userId
+    ) {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        repository.findAllByUserIdAndActiveTrue(userId)
+                .forEach(installation ->
+                        installation.deactivate(now)
+                );
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import devkor.com.teamcback.domain.bookmark.entity.Color;
 import devkor.com.teamcback.domain.bookmark.repository.BookmarkRepository;
 import devkor.com.teamcback.domain.bookmark.repository.CategoryRepository;
 import devkor.com.teamcback.domain.bookmark.repository.UserBookmarkLogRepository;
+import devkor.com.teamcback.domain.notification.service.PushInstallationService;
 import devkor.com.teamcback.domain.suggestion.entity.Suggestion;
 import devkor.com.teamcback.domain.suggestion.repository.SuggestionRepository;
 import devkor.com.teamcback.domain.user.dto.request.BypassLoginReq;
@@ -55,6 +56,7 @@ public class UserService {
     private final GoogleValidator googleValidator;
     private final AppleValidator appleValidator;
     private final PasswordEncoder passwordEncoder;
+    private final PushInstallationService pushInstallationService;
 
     private static final String DEFAULT_NAME = "호랑이";
     private static final String DEFAULT_CATEGORY = "내 장소";
@@ -183,6 +185,7 @@ public class UserService {
         }
 
         userBookmarkLogRepository.deleteAll(userBookmarkLogRepository.findByUser(user));
+        pushInstallationService.deactivateAll(user.getUserId());
 //        suggestionRepository.deleteAll(suggestionRepository.findByUser(user));
         userRepository.delete(user);
 

--- a/src/main/java/devkor/com/teamcback/global/config/TimeConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package devkor.com.teamcback.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/global/response/CommonResponse.java
+++ b/src/main/java/devkor/com/teamcback/global/response/CommonResponse.java
@@ -33,5 +33,5 @@ public class CommonResponse<T> {
     public static <T> CommonResponse<T> success(T data) {
         return new CommonResponse<>(ResultCode.SUCCESS, data);
     }
-
+    public static CommonResponse<Void> success() {return new CommonResponse<>(ResultCode.SUCCESS);}
 }

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -81,22 +81,22 @@ public class SecurityConfig {
             sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         );
 
-        http.authorizeHttpRequests(authorizeHttpRequests ->
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
-                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers(HttpMethod.POST, "/api/search/**").authenticated()
-                        .requestMatchers("/api/users/login/**").permitAll()
+                        .requestMatchers("/api/users/login/**").permitAll() // 로그인은 허용
                         .requestMatchers("/api/users/**").authenticated()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용
                         .requestMatchers("/api/categories/**").authenticated()
                         .requestMatchers("/api/bookmarks/**").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated()
-                        .requestMatchers("/api/reports/status").authenticated()
-                        .requestMatchers("/api/notifications/installations/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated() // 리뷰는 로그인 필요
+                        .requestMatchers("/api/reports/status").authenticated() // 신고 상태 확인은 로그인 필요
+                        .requestMatchers("/api/notifications/installations/**").authenticated() // 토큰 등록 로그인 필요
                         .anyRequest().permitAll()
         ).exceptionHandling(ex -> ex
-                .accessDeniedHandler(customAccessDeniedHandler())
-                .authenticationEntryPoint(customAuthenticationEntryPoint())
+                .accessDeniedHandler(customAccessDeniedHandler()) // 인가 실패 시
+                .authenticationEntryPoint(customAuthenticationEntryPoint()) // 인증 실패 시
         );
 
         http.logout(

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -81,21 +81,22 @@ public class SecurityConfig {
             sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         );
 
-        http.authorizeHttpRequests((authorizeHttpRequests) ->
-            authorizeHttpRequests
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                .requestMatchers(HttpMethod.POST, "/api/search/**").authenticated()
-                .requestMatchers("/api/users/login/**").permitAll() // 로그인은 허용
-                .requestMatchers("/api/users/**").authenticated()
-                .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자인 경우에만 허용
-                .requestMatchers("/api/categories/**").authenticated()
-                .requestMatchers("/api/bookmarks/**").authenticated()
-                .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated() // 리뷰는 로그인 필요
-                .requestMatchers("/api/reports/status").authenticated() // 신고 상태 확인은 로그인 필요
-                .anyRequest().permitAll()
+        http.authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/search/**").authenticated()
+                        .requestMatchers("/api/users/login/**").permitAll()
+                        .requestMatchers("/api/users/**").authenticated()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/categories/**").authenticated()
+                        .requestMatchers("/api/bookmarks/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated()
+                        .requestMatchers("/api/reports/status").authenticated()
+                        .requestMatchers("/api/notifications/installations/**").authenticated()
+                        .anyRequest().permitAll()
         ).exceptionHandling(ex -> ex
-            .accessDeniedHandler(customAccessDeniedHandler()) // 인가 실패 시
-            .authenticationEntryPoint(customAuthenticationEntryPoint()) // 인증 실패 시
+                .accessDeniedHandler(customAccessDeniedHandler())
+                .authenticationEntryPoint(customAuthenticationEntryPoint())
         );
 
         http.logout(


### PR DESCRIPTION
## 개요
Expo Push 알림 기능 구현을 위한 installation 등록·갱신 및 비활성화 API를 추가했습니다.  
사용자와 앱 설치 정보를 연결해 이후 푸시 발송 시 대상 기기를 구분할 수 있도록 구성했습니다.

## 작업사항
- 로그인 사용자 기준 ExpoPushToken 등록 및 갱신 기능 추가
- installationId와 ExpoPushToken 기준 멱등 처리
- 동일 installation 또는 토큰이 다른 사용자에게 등록된 경우 현재 사용자에게 재귀속
- dev, preview, production 앱 환경 구분
- 인증 사용자가 소유한 installation 비활성화 API 추가
- 회원 탈퇴 시 사용자의 활성 installation 전체 비활성화
- 푸시 installation API 인증 설정 및 Swagger 문서 추가
- 데이터가 없는 성공 응답을 위한 CommonResponse 처리 추가

## 관련 이슈
- #이슈번호
