### PR TITLE
Feat/push expo client

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushApi.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushApi.java
@@ -1,0 +1,25 @@
+package devkor.com.teamcback.domain.notification.client;
+
+import devkor.com.teamcback.domain.notification.config.ExpoPushFeignConfig;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushResponse;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoReceiptRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoReceiptResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "expoPushApi",
+        url = "${push.expo.base-url}",
+        configuration = ExpoPushFeignConfig.class
+)
+public interface ExpoPushApi {
+
+    @PostMapping("/send")
+    ExpoPushResponse send(@RequestBody List<ExpoPushRequest> requests);
+
+    @PostMapping("/getReceipts")
+    ExpoReceiptResponse getReceipts(@RequestBody ExpoReceiptRequest request);
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClient.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClient.java
@@ -1,0 +1,138 @@
+package devkor.com.teamcback.domain.notification.client;
+
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushResponse;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoReceiptRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoReceiptResponse;
+import feign.FeignException;
+import feign.RetryableException;
+import feign.codec.DecodeException;
+import feign.codec.EncodeException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExpoPushClient {
+
+    private static final int MAX_SEND_REQUEST_COUNT = 100;
+    private static final int MAX_RECEIPT_ID_COUNT = 1000;
+
+    private final ExpoPushApi expoPushApi;
+
+    public ExpoPushResponse send(List<ExpoPushRequest> requests) {
+        validateSendRequests(requests);
+
+        try {
+            ExpoPushResponse response = expoPushApi.send(requests);
+            if (response == null) {
+                throw parsingFailed();
+            }
+            return response;
+        } catch (ExpoPushClientException e) {
+            throw e;
+        } catch (RetryableException e) {
+            throw requestFailed(null, true);
+        } catch (DecodeException e) {
+            throw parsingFailed();
+        } catch (EncodeException e) {
+            throw invalidInput();
+        } catch (FeignException e) {
+            throw requestFailed(e.status(), isRetryable(e.status()));
+        }
+    }
+
+    public ExpoReceiptResponse getReceipts(List<String> ticketIds) {
+        validateReceiptIds(ticketIds);
+
+        try {
+            ExpoReceiptResponse response = expoPushApi.getReceipts(new ExpoReceiptRequest(ticketIds));
+            if (response == null) {
+                throw parsingFailed();
+            }
+            return response;
+        } catch (ExpoPushClientException e) {
+            throw e;
+        } catch (RetryableException e) {
+            throw requestFailed(null, true);
+        } catch (DecodeException e) {
+            throw parsingFailed();
+        } catch (EncodeException e) {
+            throw invalidInput();
+        } catch (FeignException e) {
+            throw requestFailed(e.status(), isRetryable(e.status()));
+        }
+    }
+
+    private void validateSendRequests(List<ExpoPushRequest> requests) {
+        if (requests == null || requests.isEmpty()) {
+            throw invalidInput();
+        }
+
+        if (requests.size() > MAX_SEND_REQUEST_COUNT) {
+            throw invalidInput();
+        }
+
+        boolean hasInvalidRequest = requests.stream()
+                .anyMatch(request -> request == null || !hasText(request.to()));
+
+        if (hasInvalidRequest) {
+            throw invalidInput();
+        }
+    }
+
+    private void validateReceiptIds(List<String> ticketIds) {
+        if (ticketIds == null || ticketIds.isEmpty()) {
+            throw invalidInput();
+        }
+
+        if (ticketIds.size() > MAX_RECEIPT_ID_COUNT) {
+            throw invalidInput();
+        }
+
+        boolean hasBlankTicketId = ticketIds.stream()
+                .anyMatch(ticketId -> !hasText(ticketId));
+
+        if (hasBlankTicketId) {
+            throw invalidInput();
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private boolean isRetryable(int status) {
+        return status == HttpStatus.TOO_MANY_REQUESTS.value()
+                || (status >= 500 && status < 600);
+    }
+
+    private ExpoPushClientException invalidInput() {
+        return new ExpoPushClientException(
+                "Invalid Expo push client request",
+                HttpStatus.BAD_REQUEST.value(),
+                false
+        );
+    }
+
+    private ExpoPushClientException parsingFailed() {
+        return new ExpoPushClientException(
+                "Failed to parse Expo push response",
+                null,
+                false
+        );
+    }
+
+    private ExpoPushClientException requestFailed(
+            Integer httpStatus,
+            boolean retryable
+    ) {
+        return new ExpoPushClientException(
+                "Expo push request failed",
+                httpStatus,
+                retryable
+        );
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClient.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClient.java
@@ -27,20 +27,18 @@ public class ExpoPushClient {
 
         try {
             ExpoPushResponse response = expoPushApi.send(requests);
-            if (response == null) {
-                throw parsingFailed();
-            }
+            validateSendResponse(response, requests.size());
             return response;
         } catch (ExpoPushClientException e) {
             throw e;
         } catch (RetryableException e) {
-            throw requestFailed(null, true);
+            throw requestFailed(null, true, e);
         } catch (DecodeException e) {
-            throw parsingFailed();
+            throw parsingFailed(e);
         } catch (EncodeException e) {
-            throw invalidInput();
+            throw invalidInput(e);
         } catch (FeignException e) {
-            throw requestFailed(e.status(), isRetryable(e.status()));
+            throw requestFailed(e.status(), isRetryable(e.status()), e);
         }
     }
 
@@ -56,13 +54,22 @@ public class ExpoPushClient {
         } catch (ExpoPushClientException e) {
             throw e;
         } catch (RetryableException e) {
-            throw requestFailed(null, true);
+            throw requestFailed(null, true, e);
         } catch (DecodeException e) {
-            throw parsingFailed();
+            throw parsingFailed(e);
         } catch (EncodeException e) {
-            throw invalidInput();
+            throw invalidInput(e);
         } catch (FeignException e) {
-            throw requestFailed(e.status(), isRetryable(e.status()));
+            throw requestFailed(e.status(), isRetryable(e.status()), e);
+        }
+    }
+
+    private void validateSendResponse(
+            ExpoPushResponse response,
+            int requestCount
+    ) {
+        if (response == null || response.data() == null || response.data().size() != requestCount) {
+            throw parsingFailed();
         }
     }
 
@@ -117,6 +124,15 @@ public class ExpoPushClient {
         );
     }
 
+    private ExpoPushClientException invalidInput(Throwable cause) {
+        return new ExpoPushClientException(
+                "Invalid Expo push client request",
+                HttpStatus.BAD_REQUEST.value(),
+                false,
+                cause
+        );
+    }
+
     private ExpoPushClientException parsingFailed() {
         return new ExpoPushClientException(
                 "Failed to parse Expo push response",
@@ -125,14 +141,25 @@ public class ExpoPushClient {
         );
     }
 
+    private ExpoPushClientException parsingFailed(Throwable cause) {
+        return new ExpoPushClientException(
+                "Failed to parse Expo push response",
+                null,
+                false,
+                cause
+        );
+    }
+
     private ExpoPushClientException requestFailed(
             Integer httpStatus,
-            boolean retryable
+            boolean retryable,
+            Throwable cause
     ) {
         return new ExpoPushClientException(
                 "Expo push request failed",
                 httpStatus,
-                retryable
+                retryable,
+                cause
         );
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClientException.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClientException.java
@@ -17,4 +17,15 @@ public class ExpoPushClientException extends RuntimeException {
         this.httpStatus = httpStatus;
         this.retryable = retryable;
     }
+
+    public ExpoPushClientException(
+            String message,
+            Integer httpStatus,
+            boolean retryable,
+            Throwable cause
+    ) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+        this.retryable = retryable;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClientException.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/client/ExpoPushClientException.java
@@ -1,0 +1,20 @@
+package devkor.com.teamcback.domain.notification.client;
+
+import lombok.Getter;
+
+@Getter
+public class ExpoPushClientException extends RuntimeException {
+
+    private final Integer httpStatus;
+    private final boolean retryable;
+
+    public ExpoPushClientException(
+            String message,
+            Integer httpStatus,
+            boolean retryable
+    ) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.retryable = retryable;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushFeignConfig.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushFeignConfig.java
@@ -1,0 +1,37 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.Retryer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+
+public class ExpoPushFeignConfig {
+
+    @Bean
+    public Request.Options expoPushRequestOptions(ExpoPushProperties properties) {
+        return new Request.Options(
+                properties.connectTimeout().toMillis(),
+                TimeUnit.MILLISECONDS,
+                properties.readTimeout().toMillis(),
+                TimeUnit.MILLISECONDS,
+                true
+        );
+    }
+
+    @Bean
+    public RequestInterceptor expoPushAuthorizationInterceptor(ExpoPushProperties properties) {
+        return template -> {
+            if (StringUtils.hasText(properties.accessToken())) {
+                template.header(HttpHeaders.AUTHORIZATION, "Bearer " + properties.accessToken());
+            }
+        };
+    }
+
+    @Bean
+    public Retryer expoPushRetryer() {
+        return Retryer.NEVER_RETRY;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushProperties.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushProperties.java
@@ -1,0 +1,28 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "push.expo")
+public record ExpoPushProperties(
+        String baseUrl,
+        String accessToken,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+
+    public ExpoPushProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "https://exp.host/--/api/v2/push";
+        }
+        if (accessToken == null) {
+            accessToken = "";
+        }
+        if (connectTimeout == null) {
+            connectTimeout = Duration.ofSeconds(3);
+        }
+        if (readTimeout == null) {
+            readTimeout = Duration.ofSeconds(10);
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
@@ -1,0 +1,9 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ExpoPushProperties.class)
+public class ExpoPushPropertiesConfig {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/controller/NotificationTestController.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/controller/NotificationTestController.java
@@ -1,0 +1,71 @@
+package devkor.com.teamcback.domain.notification.controller;
+
+import devkor.com.teamcback.domain.notification.dto.request.NotificationTestReq;
+import devkor.com.teamcback.domain.notification.dto.response.NotificationTestRes;
+import devkor.com.teamcback.domain.notification.service.NotificationTestService;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import devkor.com.teamcback.global.response.CommonResponse;
+import devkor.com.teamcback.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationTestController {
+
+    private final NotificationTestService notificationTestService;
+
+    /**
+     * DEV/PREVIEW 환경에서 실제 기기 푸시 수신을 확인하는 API입니다.
+     * 테스트 코드가 아닌 애플리케이션 기능입니다.
+     */
+    @Operation(
+            summary = "푸시 알림 테스트 발송",
+            description = """
+                    인증된 사용자의 본인 DEV/PREVIEW installation 한 대에
+                    실제 테스트 푸시를 발송합니다.
+                    PRODUCTION installation은 사용할 수 없습니다.
+                    """
+    )
+    @PostMapping("/test")
+    public ResponseEntity<CommonResponse<NotificationTestRes>> sendTest(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetail,
+
+            @Parameter(
+                    description = "중복 발송 방지를 위한 멱등성 키",
+                    required = true,
+                    example = "7b347ad7-6138-4cb7-af7d-f5201703a596"
+            )
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            String idempotencyKey,
+
+            @Valid @RequestBody NotificationTestReq request
+    ) {
+        if (userDetail == null) {
+            throw new GlobalException(UNAUTHORIZED);
+        }
+
+        Long userId = userDetail.getUser().getUserId();
+
+        return ResponseEntity.ok(CommonResponse.success(
+                notificationTestService.sendTest(
+                        userId,
+                        idempotencyKey,
+                        request
+                )
+        ));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushErrorDetails.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushErrorDetails.java
@@ -1,0 +1,9 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoPushErrorDetails(
+        String error
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushReceipt.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushReceipt.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoPushReceipt(
+        String status,
+        String message,
+        ExpoPushErrorDetails details
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushRequest.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushRequest.java
@@ -1,0 +1,13 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoPushRequest(
+        String to,
+        String title,
+        String body,
+        Map<String, Object> data
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushRequest.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushRequest.java
@@ -1,13 +1,13 @@
 package devkor.com.teamcback.domain.notification.dto.expo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ExpoPushRequest(
         String to,
         String title,
         String body,
-        Map<String, Object> data
+        String sound,
+        Object data
 ) {
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushResponse.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushResponse.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoPushResponse(
+        List<ExpoPushTicket> data
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushTicket.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoPushTicket.java
@@ -1,0 +1,12 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoPushTicket(
+        String status,
+        String id,
+        String message,
+        ExpoPushErrorDetails details
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoReceiptRequest.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoReceiptRequest.java
@@ -1,0 +1,8 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import java.util.List;
+
+public record ExpoReceiptRequest(
+        List<String> ids
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoReceiptResponse.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/expo/ExpoReceiptResponse.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.notification.dto.expo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoReceiptResponse(
+        Map<String, ExpoPushReceipt> data
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/request/NotificationTestReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/request/NotificationTestReq.java
@@ -1,0 +1,19 @@
+package devkor.com.teamcback.domain.notification.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NotificationTestReq(
+        @NotNull
+        @Min(1)
+        @Max(1)
+        Integer schemaVersion,
+
+        @NotBlank
+        @Size(max = 64)
+        String installationId
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/NotificationTestRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/NotificationTestRes.java
@@ -1,0 +1,12 @@
+package devkor.com.teamcback.domain.notification.dto.response;
+
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+
+public record NotificationTestRes(
+        String notificationId,
+        String installationId,
+        AppVariant appVariant,
+        String ticketStatus,
+        String ticketId
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
@@ -112,4 +112,32 @@ public class PushMessage {
         this.createdAt = now;
         this.updatedAt = now;
     }
+
+    public void recordTicket(
+            String ticketStatus,
+            String expoTicketId,
+            String ticketError,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = ticketStatus;
+        this.expoTicketId = expoTicketId;
+        this.ticketError = ticketError;
+        this.sendAttempts += 1;
+        this.sentAt = now;
+        this.updatedAt = now;
+        this.status = "ok".equals(ticketStatus)
+                ? PushMessageStatus.RECEIPT_PENDING
+                : PushMessageStatus.FAILED;
+    }
+
+    public void recordClientError(
+            boolean retryable,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = "client_error";
+        this.ticketError = retryable ? "retryable" : "non_retryable";
+        this.sendAttempts += 1;
+        this.updatedAt = now;
+        this.status = PushMessageStatus.FAILED;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/NotificationTestService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/NotificationTestService.java
@@ -1,0 +1,274 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.client.ExpoPushClient;
+import devkor.com.teamcback.domain.notification.client.ExpoPushClientException;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushResponse;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushTicket;
+import devkor.com.teamcback.domain.notification.dto.request.NotificationTestReq;
+import devkor.com.teamcback.domain.notification.dto.response.NotificationTestRes;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_NON_RETRYABLE_ERROR;
+import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_RETRYABLE_ERROR;
+import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_TICKET_ERROR;
+import static devkor.com.teamcback.global.response.ResultCode.FORBIDDEN_PUSH_INSTALLATION;
+import static devkor.com.teamcback.global.response.ResultCode.INACTIVE_PUSH_INSTALLATION;
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_INPUT;
+import static devkor.com.teamcback.global.response.ResultCode.NOT_FOUND_PUSH_INSTALLATION;
+import static devkor.com.teamcback.global.response.ResultCode.UNSUPPORTED_PUSH_INSTALLATION_VARIANT;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationTestService {
+
+    private static final int MAX_IDEMPOTENCY_KEY_LENGTH = 128;
+    private static final int SCHEMA_VERSION = 1;
+    private static final String TEST_TITLE = "고대로 테스트 알림";
+    private static final String TEST_BODY = "푸시 알림 연결이 정상적으로 동작합니다.";
+    private static final String DEFAULT_SOUND = "default";
+    private static final String TICKET_STATUS_OK = "ok";
+    private static final String CLIENT_ERROR_STATUS = "client_error";
+    private static final String RETRYABLE_ERROR = "retryable";
+
+    private final PushInstallationRepository pushInstallationRepository;
+    private final PushDispatchRepository pushDispatchRepository;
+    private final PushMessageRepository pushMessageRepository;
+    private final PushPayloadFactory pushPayloadFactory;
+    private final ExpoPushClient expoPushClient;
+    private final Clock clock;
+
+    public NotificationTestRes sendTest(
+            Long userId,
+            String idempotencyKey,
+            NotificationTestReq request
+    ) {
+        validateRequest(userId, idempotencyKey, request);
+
+        PushInstallation installation = findAndValidateInstallation(
+                userId,
+                request.installationId()
+        );
+
+        return pushDispatchRepository.findByIdempotencyKey(idempotencyKey)
+                .map(dispatch -> responseFromExistingDispatch(dispatch, installation))
+                .orElseGet(() -> createAndSend(
+                        userId,
+                        idempotencyKey,
+                        installation
+                ));
+    }
+
+    private NotificationTestRes createAndSend(
+            Long userId,
+            String idempotencyKey,
+            PushInstallation installation
+    ) {
+        String notificationId = UUID.randomUUID().toString();
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        PushDispatch dispatch;
+        PushMessage message;
+
+        try {
+            dispatch = pushDispatchRepository.saveAndFlush(new PushDispatch(
+                    NotificationType.GENERAL,
+                    PushMode.TEST,
+                    installation.getAppVariant(),
+                    PushTargetType.INSTALLATION,
+                    installation.getInstallationId(),
+                    TEST_TITLE,
+                    TEST_BODY,
+                    PushActionType.TEST,
+                    notificationId,
+                    idempotencyKey,
+                    userId,
+                    now
+            ));
+
+            message = pushMessageRepository.saveAndFlush(new PushMessage(
+                    dispatch,
+                    installation,
+                    now
+            ));
+
+            dispatch.updateRecipientCount(1);
+            pushDispatchRepository.save(dispatch);
+        } catch (DataIntegrityViolationException e) {
+            return pushDispatchRepository.findByIdempotencyKey(idempotencyKey)
+                    .map(dispatchFromRace -> responseFromExistingDispatch(dispatchFromRace, installation))
+                    .orElseThrow(() -> new GlobalException(EXPO_PUSH_NON_RETRYABLE_ERROR));
+        }
+
+        try {
+            ExpoPushResponse response = expoPushClient.send(List.of(new ExpoPushRequest(
+                    installation.getExpoPushToken(),
+                    TEST_TITLE,
+                    TEST_BODY,
+                    DEFAULT_SOUND,
+                    pushPayloadFactory.create(
+                            notificationId,
+                            TEST_TITLE,
+                            TEST_BODY,
+                            PushMode.TEST,
+                            installation.getAppVariant(),
+                            PushActionType.TEST,
+                            Collections.emptyMap()
+                    ).data()
+            )));
+
+            ExpoPushTicket ticket = response.data().get(0);
+            message.recordTicket(
+                    ticket.status(),
+                    ticket.id(),
+                    ticket.details() == null ? null : ticket.details().error(),
+                    LocalDateTime.now(clock)
+            );
+            pushMessageRepository.save(message);
+
+            if (!TICKET_STATUS_OK.equals(ticket.status())) {
+                throw new GlobalException(EXPO_PUSH_TICKET_ERROR);
+            }
+
+            return new NotificationTestRes(
+                    notificationId,
+                    installation.getInstallationId(),
+                    installation.getAppVariant(),
+                    ticket.status(),
+                    ticket.id()
+            );
+        } catch (ExpoPushClientException e) {
+            message.recordClientError(
+                    e.isRetryable(),
+                    LocalDateTime.now(clock)
+            );
+            pushMessageRepository.save(message);
+            throw new GlobalException(e.isRetryable()
+                    ? EXPO_PUSH_RETRYABLE_ERROR
+                    : EXPO_PUSH_NON_RETRYABLE_ERROR);
+        }
+    }
+
+    private NotificationTestRes responseFromExistingDispatch(
+            PushDispatch dispatch,
+            PushInstallation installation
+    ) {
+        List<PushMessage> messages = pushMessageRepository.findAllByDispatch(dispatch);
+
+        if (messages.size() != 1) {
+            throw new GlobalException(EXPO_PUSH_NON_RETRYABLE_ERROR);
+        }
+
+        PushMessage message = messages.get(0);
+
+        if (!installation.getInstallationId().equals(message.getInstallationId())) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        if (message.getTicketStatus() == null) {
+            throw new GlobalException(EXPO_PUSH_RETRYABLE_ERROR);
+        }
+
+        if (CLIENT_ERROR_STATUS.equals(message.getTicketStatus())) {
+            throw new GlobalException(RETRYABLE_ERROR.equals(message.getTicketError())
+                    ? EXPO_PUSH_RETRYABLE_ERROR
+                    : EXPO_PUSH_NON_RETRYABLE_ERROR);
+        }
+
+        if (!TICKET_STATUS_OK.equals(message.getTicketStatus())) {
+            throw new GlobalException(EXPO_PUSH_TICKET_ERROR);
+        }
+
+        return new NotificationTestRes(
+                dispatch.getActionParams(),
+                message.getInstallationId(),
+                dispatch.getAppVariant(),
+                message.getTicketStatus(),
+                message.getExpoTicketId()
+        );
+    }
+
+    private PushInstallation findAndValidateInstallation(
+            Long userId,
+            String installationId
+    ) {
+        PushInstallation installation = pushInstallationRepository.findByInstallationId(installationId)
+                .orElseThrow(() -> new GlobalException(NOT_FOUND_PUSH_INSTALLATION));
+
+        if (!userId.equals(installation.getUserId())) {
+            throw new GlobalException(FORBIDDEN_PUSH_INSTALLATION);
+        }
+
+        if (!installation.isActive()) {
+            throw new GlobalException(INACTIVE_PUSH_INSTALLATION);
+        }
+
+        if (AppVariant.PRODUCTION.equals(installation.getAppVariant())) {
+            throw new GlobalException(UNSUPPORTED_PUSH_INSTALLATION_VARIANT);
+        }
+
+        if (!AppVariant.DEV.equals(installation.getAppVariant())
+                && !AppVariant.PREVIEW.equals(installation.getAppVariant())) {
+            throw new GlobalException(UNSUPPORTED_PUSH_INSTALLATION_VARIANT);
+        }
+
+        if (!hasText(installation.getExpoPushToken())) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        return installation;
+    }
+
+    private void validateRequest(
+            Long userId,
+            String idempotencyKey,
+            NotificationTestReq request
+    ) {
+        if (userId == null || request == null || request.schemaVersion() == null
+                || request.schemaVersion() != SCHEMA_VERSION) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        validateText(request.installationId(), 64);
+        validateText(idempotencyKey, MAX_IDEMPOTENCY_KEY_LENGTH);
+
+        try {
+            UUID.fromString(idempotencyKey);
+        } catch (IllegalArgumentException e) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+    }
+
+    private void validateText(
+            String value,
+            int maxLength
+    ) {
+        if (!hasText(value) || value.length() > maxLength) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/devkor/com/teamcback/global/jwt/JwtAuthorizationFilter.java
@@ -53,7 +53,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         throws ServletException, IOException {
 
         String accessToken = jwtUtil.getAccessTokenFromHeader(request);
-        log.info("Access Token: {}", accessToken);
 
         // access token 비어있으면 인증 미처리
         if (!StringUtils.hasText(accessToken)) {

--- a/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
+++ b/src/main/java/devkor/com/teamcback/global/response/ResultCode.java
@@ -102,7 +102,16 @@ public enum ResultCode {
     COMMENT_TOO_SHORT(HttpStatus.BAD_REQUEST, 15003, "한줄평은 10글자 이상 작성해주세요."),
 
     // 신고 16000번대
-    NOT_FOUND_REPORT(HttpStatus.NOT_FOUND, 16000, "신고를 찾을 수 없습니다.");
+    NOT_FOUND_REPORT(HttpStatus.NOT_FOUND, 16000, "신고를 찾을 수 없습니다."),
+
+    // notification 17000
+    NOT_FOUND_PUSH_INSTALLATION(HttpStatus.NOT_FOUND, 17000, "Push installation not found."),
+    FORBIDDEN_PUSH_INSTALLATION(HttpStatus.FORBIDDEN, 17001, "Push installation is not owned by the current user."),
+    INACTIVE_PUSH_INSTALLATION(HttpStatus.BAD_REQUEST, 17002, "Push installation is inactive."),
+    UNSUPPORTED_PUSH_INSTALLATION_VARIANT(HttpStatus.BAD_REQUEST, 17003, "Push installation variant is not supported for test push."),
+    EXPO_PUSH_RETRYABLE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 17004, "Expo push request failed with retryable error."),
+    EXPO_PUSH_NON_RETRYABLE_ERROR(HttpStatus.BAD_GATEWAY, 17005, "Expo push request failed with non-retryable error."),
+    EXPO_PUSH_TICKET_ERROR(HttpStatus.BAD_GATEWAY, 17006, "Expo push ticket returned error status.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
+++ b/src/main/java/devkor/com/teamcback/global/security/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated() // 리뷰는 로그인 필요
                         .requestMatchers("/api/reports/status").authenticated() // 신고 상태 확인은 로그인 필요
                         .requestMatchers("/api/notifications/installations/**").authenticated() // 토큰 등록 로그인 필요
+                        .requestMatchers(HttpMethod.POST, "/api/notifications/test").authenticated()
                         .anyRequest().permitAll()
         ).exceptionHandling(ex -> ex
                 .accessDeniedHandler(customAccessDeniedHandler()) // 인가 실패 시

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,3 +152,10 @@ management:
 
 staff:
   emails: leeyejin113@gmail.com,pingdoll3110@naver.com,ku.kodaero@gmail.com
+
+push:
+  expo:
+    base-url: https://exp.host/--/api/v2/push
+    access-token: ${EXPO_ACCESS_TOKEN:}
+    connect-timeout: 3s
+    read-timeout: 10s


### PR DESCRIPTION
## 개요
Expo Push API 연동 클라이언트와 로그인 사용자의 DEV/PREVIEW 기기 한 대에
테스트 푸시를 발송하는 API를 구현했습니다.

## 작업사항
- Expo `/send`, `/getReceipts` Feign Client 추가
- Expo 요청·ticket·receipt 응답 DTO 추가
- timeout 및 선택적 Expo Access Token 설정
- 네트워크·HTTP 상태별 retryable 오류 분류
- `POST /api/notifications/test` 추가
- 로그인 사용자의 본인 active installation 검증
- DEV/PREVIEW installation만 테스트 발송 허용
- PRODUCTION installation 테스트 발송 거부
- Idempotency-Key 기반 중복 발송 방지
- ExpoPushToken 및 인증 정보 로그 노출 방지


## 관련 이슈
- 없음

