### PR TITLE
feat: Expo push 발송 및 receipt 처리 worker 구현

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
@@ -7,7 +7,8 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties({
         ExpoPushProperties.class,
         PushWorkerProperties.class,
-        PushReceiptWorkerProperties.class
+        PushReceiptWorkerProperties.class,
+        PushRecoveryWorkerProperties.class
 })
 public class ExpoPushPropertiesConfig {
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
@@ -6,7 +6,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties({
         ExpoPushProperties.class,
-        PushWorkerProperties.class
+        PushWorkerProperties.class,
+        PushReceiptWorkerProperties.class
 })
 public class ExpoPushPropertiesConfig {
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/ExpoPushPropertiesConfig.java
@@ -4,6 +4,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(ExpoPushProperties.class)
+@EnableConfigurationProperties({
+        ExpoPushProperties.class,
+        PushWorkerProperties.class
+})
 public class ExpoPushPropertiesConfig {
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/PushReceiptWorkerProperties.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/PushReceiptWorkerProperties.java
@@ -1,0 +1,22 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "push.receipt-worker")
+public record PushReceiptWorkerProperties(
+        boolean enabled,
+        int batchSize,
+        int maxReceiptAttempts
+) {
+
+    private static final int MAX_EXPO_RECEIPT_BATCH_SIZE = 1000;
+
+    public PushReceiptWorkerProperties {
+        if (batchSize <= 0 || batchSize > MAX_EXPO_RECEIPT_BATCH_SIZE) {
+            batchSize = MAX_EXPO_RECEIPT_BATCH_SIZE;
+        }
+        if (maxReceiptAttempts <= 0) {
+            maxReceiptAttempts = 3;
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/PushRecoveryWorkerProperties.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/PushRecoveryWorkerProperties.java
@@ -1,0 +1,24 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "push.recovery-worker")
+public record PushRecoveryWorkerProperties(
+        boolean enabled,
+        String cron,
+        long staleThresholdMinutes,
+        int batchSize
+) {
+
+    private static final int DEFAULT_BATCH_SIZE = 100;
+    private static final long DEFAULT_STALE_THRESHOLD_MINUTES = 30L;
+
+    public PushRecoveryWorkerProperties {
+        if (staleThresholdMinutes <= 0) {
+            staleThresholdMinutes = DEFAULT_STALE_THRESHOLD_MINUTES;
+        }
+        if (batchSize <= 0) {
+            batchSize = DEFAULT_BATCH_SIZE;
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/config/PushWorkerProperties.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/config/PushWorkerProperties.java
@@ -1,0 +1,26 @@
+package devkor.com.teamcback.domain.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "push.worker")
+public record PushWorkerProperties(
+        boolean enabled,
+        int batchSize,
+        int maxSendAttempts,
+        long retryDelayMs
+) {
+
+    private static final int MAX_EXPO_BATCH_SIZE = 100;
+
+    public PushWorkerProperties {
+        if (batchSize <= 0 || batchSize > MAX_EXPO_BATCH_SIZE) {
+            batchSize = MAX_EXPO_BATCH_SIZE;
+        }
+        if (maxSendAttempts <= 0) {
+            maxSendAttempts = 3;
+        }
+        if (retryDelayMs <= 0) {
+            retryDelayMs = 30_000L;
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/NotificationTestRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/NotificationTestRes.java
@@ -1,12 +1,13 @@
 package devkor.com.teamcback.domain.notification.dto.response;
 
 import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
 
 public record NotificationTestRes(
         String notificationId,
         String installationId,
         AppVariant appVariant,
-        String ticketStatus,
+        PushMessageStatus messageStatus,
         String ticketId
 ) {
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushReceiptItem.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushReceiptItem.java
@@ -1,0 +1,8 @@
+package devkor.com.teamcback.domain.notification.dto.worker;
+
+public record PushReceiptItem(
+        Long pushMessageId,
+        Long pushDispatchId,
+        String expoTicketId
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushReceiptWorkerResult.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushReceiptWorkerResult.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.notification.dto.worker;
+
+public record PushReceiptWorkerResult(
+        int claimedCount,
+        int checkedCount
+) {
+
+    public static PushReceiptWorkerResult empty() {
+        return new PushReceiptWorkerResult(0, 0);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushSendItem.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushSendItem.java
@@ -1,0 +1,10 @@
+package devkor.com.teamcback.domain.notification.dto.worker;
+
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
+
+public record PushSendItem(
+        Long pushMessageId,
+        Long pushDispatchId,
+        ExpoPushRequest request
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushWorkerDispatchResult.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/worker/PushWorkerDispatchResult.java
@@ -1,0 +1,11 @@
+package devkor.com.teamcback.domain.notification.dto.worker;
+
+public record PushWorkerDispatchResult(
+        int claimedCount,
+        int sentCount
+) {
+
+    public static PushWorkerDispatchResult empty() {
+        return new PushWorkerDispatchResult(0, 0);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushDispatch.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushDispatch.java
@@ -125,4 +125,32 @@ public class PushDispatch {
     public void updateRecipientCount(int recipientCount) {
         this.recipientCount = recipientCount;
     }
+
+    public void updateStatusFromMessageSummary(
+            long queuedCount,
+            long sendingCount,
+            long successCount,
+            long failedCount,
+            LocalDateTime now
+    ) {
+        if (queuedCount > 0 || sendingCount > 0) {
+            this.status = PushDispatchStatus.PROCESSING;
+            return;
+        }
+
+        if (failedCount == 0 && successCount == recipientCount) {
+            this.status = PushDispatchStatus.COMPLETED;
+            this.completedAt = now;
+            return;
+        }
+
+        if (failedCount == recipientCount) {
+            this.status = PushDispatchStatus.FAILED;
+            this.completedAt = now;
+            return;
+        }
+
+        this.status = PushDispatchStatus.PARTIAL_FAILED;
+        this.completedAt = now;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
@@ -128,6 +128,34 @@ public class PushMessage {
         this.status = "ok".equals(ticketStatus)
                 ? PushMessageStatus.RECEIPT_PENDING
                 : PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
+    }
+
+    public void markSending(LocalDateTime now) {
+        this.status = PushMessageStatus.SENDING;
+        this.updatedAt = now;
+    }
+
+    public void recordRetryableTicketError(
+            String ticketStatus,
+            String ticketError,
+            int maxSendAttempts,
+            LocalDateTime nextRetryAt,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = ticketStatus;
+        this.expoTicketId = null;
+        this.ticketError = ticketError;
+        this.sendAttempts += 1;
+        this.sentAt = now;
+        this.updatedAt = now;
+        if (sendAttempts < maxSendAttempts) {
+            this.status = PushMessageStatus.QUEUED;
+            this.nextRetryAt = nextRetryAt;
+            return;
+        }
+        this.status = PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
     }
 
     public void recordClientError(
@@ -139,5 +167,40 @@ public class PushMessage {
         this.sendAttempts += 1;
         this.updatedAt = now;
         this.status = PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
+    }
+
+    public void recordClientError(
+            boolean retryable,
+            String ticketError,
+            int maxSendAttempts,
+            LocalDateTime nextRetryAt,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = "client_error";
+        this.expoTicketId = null;
+        this.ticketError = ticketError;
+        this.sendAttempts += 1;
+        this.updatedAt = now;
+        if (retryable && sendAttempts < maxSendAttempts) {
+            this.status = PushMessageStatus.QUEUED;
+            this.nextRetryAt = nextRetryAt;
+            return;
+        }
+        this.status = PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
+    }
+
+    public void recordSkipped(
+            String ticketStatus,
+            String ticketError,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = ticketStatus;
+        this.expoTicketId = null;
+        this.ticketError = ticketError;
+        this.status = PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
+        this.updatedAt = now;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
@@ -81,6 +81,9 @@ public class PushMessage {
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
 
+    @Column(name = "receipt_available_at")
+    private LocalDateTime receiptAvailableAt;
+
     @Column(name = "receipt_checked_at")
     private LocalDateTime receiptCheckedAt;
 
@@ -108,6 +111,7 @@ public class PushMessage {
         this.receiptAttempts = 0;
         this.nextRetryAt = null;
         this.sentAt = null;
+        this.receiptAvailableAt = null;
         this.receiptCheckedAt = null;
         this.createdAt = now;
         this.updatedAt = now;
@@ -128,12 +132,64 @@ public class PushMessage {
         this.status = "ok".equals(ticketStatus)
                 ? PushMessageStatus.RECEIPT_PENDING
                 : PushMessageStatus.FAILED;
+        this.receiptAvailableAt = "ok".equals(ticketStatus) ? now.plusMinutes(15) : null;
         this.nextRetryAt = null;
     }
 
     public void markSending(LocalDateTime now) {
         this.status = PushMessageStatus.SENDING;
         this.updatedAt = now;
+    }
+
+    public void markReceiptChecking(LocalDateTime now) {
+        this.status = PushMessageStatus.SENDING;
+        this.updatedAt = now;
+    }
+
+    public void recordReceipt(
+            String receiptStatus,
+            String receiptError,
+            LocalDateTime now
+    ) {
+        this.receiptStatus = receiptStatus;
+        this.receiptError = "ok".equals(receiptStatus) ? null : receiptError;
+        this.receiptAttempts += 1;
+        this.receiptCheckedAt = now;
+        this.receiptAvailableAt = null;
+        this.updatedAt = now;
+        this.status = "ok".equals(receiptStatus)
+                ? PushMessageStatus.DELIVERED
+                : PushMessageStatus.FAILED;
+    }
+
+    public void scheduleReceiptRetry(
+            String receiptStatus,
+            String receiptError,
+            int maxReceiptAttempts,
+            LocalDateTime nextReceiptAvailableAt,
+            LocalDateTime now
+    ) {
+        this.receiptStatus = receiptStatus;
+        this.receiptError = receiptError;
+        this.receiptAttempts += 1;
+        this.receiptCheckedAt = now;
+        this.updatedAt = now;
+        if (receiptAttempts < maxReceiptAttempts) {
+            this.status = PushMessageStatus.RECEIPT_PENDING;
+            this.receiptAvailableAt = nextReceiptAvailableAt;
+            return;
+        }
+        this.status = PushMessageStatus.FAILED;
+        this.receiptAvailableAt = null;
+    }
+
+    public void recordReceiptExpired(LocalDateTime now) {
+        this.receiptStatus = "expired";
+        this.receiptError = "receipt_expired";
+        this.receiptCheckedAt = now;
+        this.receiptAvailableAt = null;
+        this.updatedAt = now;
+        this.status = PushMessageStatus.FAILED;
     }
 
     public void recordRetryableTicketError(
@@ -152,10 +208,12 @@ public class PushMessage {
         if (sendAttempts < maxSendAttempts) {
             this.status = PushMessageStatus.QUEUED;
             this.nextRetryAt = nextRetryAt;
+            this.receiptAvailableAt = null;
             return;
         }
         this.status = PushMessageStatus.FAILED;
         this.nextRetryAt = null;
+        this.receiptAvailableAt = null;
     }
 
     public void recordClientError(
@@ -168,6 +226,7 @@ public class PushMessage {
         this.updatedAt = now;
         this.status = PushMessageStatus.FAILED;
         this.nextRetryAt = null;
+        this.receiptAvailableAt = null;
     }
 
     public void recordClientError(
@@ -185,10 +244,12 @@ public class PushMessage {
         if (retryable && sendAttempts < maxSendAttempts) {
             this.status = PushMessageStatus.QUEUED;
             this.nextRetryAt = nextRetryAt;
+            this.receiptAvailableAt = null;
             return;
         }
         this.status = PushMessageStatus.FAILED;
         this.nextRetryAt = null;
+        this.receiptAvailableAt = null;
     }
 
     public void recordSkipped(
@@ -201,6 +262,7 @@ public class PushMessage {
         this.ticketError = ticketError;
         this.status = PushMessageStatus.FAILED;
         this.nextRetryAt = null;
+        this.receiptAvailableAt = null;
         this.updatedAt = now;
     }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/entity/PushMessage.java
@@ -265,4 +265,26 @@ public class PushMessage {
         this.receiptAvailableAt = null;
         this.updatedAt = now;
     }
+
+    public void recoverInterruptedSendingWithoutTicket(
+            String ticketError,
+            LocalDateTime now
+    ) {
+        this.ticketStatus = "worker_interrupted";
+        this.expoTicketId = null;
+        this.ticketError = ticketError;
+        this.status = PushMessageStatus.FAILED;
+        this.nextRetryAt = null;
+        this.receiptAvailableAt = null;
+        this.updatedAt = now;
+    }
+
+    public void recoverInterruptedSendingWithTicket(LocalDateTime now) {
+        this.status = PushMessageStatus.RECEIPT_PENDING;
+        this.nextRetryAt = null;
+        if (this.receiptAvailableAt == null) {
+            this.receiptAvailableAt = now;
+        }
+        this.updatedAt = now;
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/factory/PushPayloadFactory.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/factory/PushPayloadFactory.java
@@ -1,6 +1,7 @@
 package devkor.com.teamcback.domain.notification.factory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import devkor.com.teamcback.domain.notification.dto.payload.PushPayload;
 import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
@@ -85,6 +86,19 @@ public class PushPayloadFactory {
     public String serializeActionParams(Map<String, Object> actionParams) {
         try {
             return objectMapper.writeValueAsString(actionParams);
+        } catch (JsonProcessingException e) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+    }
+
+    public Map<String, Object> deserializeActionParams(String actionParams) {
+        if (actionParams == null || actionParams.isBlank()) {
+            return Map.of();
+        }
+
+        try {
+            return objectMapper.readValue(actionParams, new TypeReference<>() {
+            });
         } catch (JsonProcessingException e) {
             throw new GlobalException(INVALID_INPUT);
         }

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
@@ -35,4 +35,10 @@ public interface PushInstallationRepository extends JpaRepository<PushInstallati
             Long userId,
             AppVariant appVariant
     );
+
+    Optional<PushInstallation> findByPushInstallationIdAndInstallationIdAndAppVariantAndActiveTrue(
+            Long pushInstallationId,
+            String installationId,
+            AppVariant appVariant
+    );
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
@@ -54,6 +54,23 @@ public interface PushMessageRepository extends JpaRepository<PushMessage, Long> 
             @Param("limit") int limit
     );
 
+    @Query(
+            value = """
+                    SELECT *
+                    FROM tb_push_message
+                    WHERE status = 'SENDING'
+                      AND updated_at <= :staleBefore
+                    ORDER BY updated_at ASC, push_message_id ASC
+                    LIMIT :limit
+                    FOR UPDATE SKIP LOCKED
+                    """,
+            nativeQuery = true
+    )
+    List<PushMessage> findStaleSendingForUpdateSkipLocked(
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("limit") int limit
+    );
+
     @EntityGraph(attributePaths = "dispatch")
     List<PushMessage> findAllByPushMessageIdIn(
             Collection<Long> pushMessageIds

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
@@ -2,12 +2,60 @@ package devkor.com.teamcback.domain.notification.repository;
 
 import devkor.com.teamcback.domain.notification.entity.PushDispatch;
 import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Collection;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PushMessageRepository extends JpaRepository<PushMessage, Long> {
 
     List<PushMessage> findAllByDispatch(
             PushDispatch dispatch
     );
+
+    @Query(
+            value = """
+                    SELECT *
+                    FROM tb_push_message
+                    WHERE status = 'QUEUED'
+                      AND (next_retry_at IS NULL OR next_retry_at <= :now)
+                    ORDER BY created_at ASC, push_message_id ASC
+                    LIMIT :limit
+                    FOR UPDATE SKIP LOCKED
+                    """,
+            nativeQuery = true
+    )
+    List<PushMessage> findDueQueuedForUpdateSkipLocked(
+            @Param("now") LocalDateTime now,
+            @Param("limit") int limit
+    );
+
+    @EntityGraph(attributePaths = "dispatch")
+    List<PushMessage> findAllByPushMessageIdIn(
+            Collection<Long> pushMessageIds
+    );
+
+    @Query("""
+            SELECT m.dispatch.pushDispatchId AS dispatchId,
+                   m.status AS status,
+                   COUNT(m) AS count
+            FROM PushMessage m
+            WHERE m.dispatch.pushDispatchId IN :dispatchIds
+            GROUP BY m.dispatch.pushDispatchId, m.status
+            """)
+    List<PushDispatchMessageStatusCount> countStatusesByDispatchIds(
+            @Param("dispatchIds") Collection<Long> dispatchIds
+    );
+
+    interface PushDispatchMessageStatusCount {
+        Long getDispatchId();
+
+        PushMessageStatus getStatus();
+
+        long getCount();
+    }
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepository.java
@@ -34,6 +34,26 @@ public interface PushMessageRepository extends JpaRepository<PushMessage, Long> 
             @Param("limit") int limit
     );
 
+    @Query(
+            value = """
+                    SELECT *
+                    FROM tb_push_message
+                    WHERE status = 'RECEIPT_PENDING'
+                      AND expo_ticket_id IS NOT NULL
+                      AND expo_ticket_id <> ''
+                      AND receipt_available_at IS NOT NULL
+                      AND receipt_available_at <= :now
+                    ORDER BY receipt_available_at ASC, push_message_id ASC
+                    LIMIT :limit
+                    FOR UPDATE SKIP LOCKED
+                    """,
+            nativeQuery = true
+    )
+    List<PushMessage> findDueReceiptPendingForUpdateSkipLocked(
+            @Param("now") LocalDateTime now,
+            @Param("limit") int limit
+    );
+
     @EntityGraph(attributePaths = "dispatch")
     List<PushMessage> findAllByPushMessageIdIn(
             Collection<Long> pushMessageIds

--- a/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageRecoveryScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageRecoveryScheduler.java
@@ -1,0 +1,20 @@
+package devkor.com.teamcback.domain.notification.scheduler;
+
+import devkor.com.teamcback.domain.notification.service.PushMessageRecoveryWorker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "push.recovery-worker", name = "enabled", havingValue = "true")
+public class PushMessageRecoveryScheduler {
+
+    private final PushMessageRecoveryWorker pushMessageRecoveryWorker;
+
+    @Scheduled(cron = "${push.recovery-worker.cron:0 0 4 * * *}")
+    public void recoverStaleSendingMessages() {
+        pushMessageRecoveryWorker.recoverStaleSendingMessages();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageWorkerScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageWorkerScheduler.java
@@ -1,0 +1,20 @@
+package devkor.com.teamcback.domain.notification.scheduler;
+
+import devkor.com.teamcback.domain.notification.service.PushMessageDispatchWorker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "push.worker", name = "enabled", havingValue = "true")
+public class PushMessageWorkerScheduler {
+
+    private final PushMessageDispatchWorker pushMessageDispatchWorker;
+
+    @Scheduled(fixedDelayString = "${push.worker.fixed-delay-ms:5000}")
+    public void dispatchQueuedMessages() {
+        pushMessageDispatchWorker.dispatchPending();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushReceiptWorkerScheduler.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/scheduler/PushReceiptWorkerScheduler.java
@@ -1,0 +1,20 @@
+package devkor.com.teamcback.domain.notification.scheduler;
+
+import devkor.com.teamcback.domain.notification.service.PushReceiptWorker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "push.receipt-worker", name = "enabled", havingValue = "true")
+public class PushReceiptWorkerScheduler {
+
+    private final PushReceiptWorker pushReceiptWorker;
+
+    @Scheduled(fixedDelayString = "${push.receipt-worker.fixed-delay-ms:60000}")
+    public void checkPendingReceipts() {
+        pushReceiptWorker.checkPendingReceipts();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/NotificationTestService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/NotificationTestService.java
@@ -1,10 +1,5 @@
 package devkor.com.teamcback.domain.notification.service;
 
-import devkor.com.teamcback.domain.notification.client.ExpoPushClient;
-import devkor.com.teamcback.domain.notification.client.ExpoPushClientException;
-import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
-import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushResponse;
-import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushTicket;
 import devkor.com.teamcback.domain.notification.dto.request.NotificationTestReq;
 import devkor.com.teamcback.domain.notification.dto.response.NotificationTestRes;
 import devkor.com.teamcback.domain.notification.entity.PushDispatch;
@@ -30,8 +25,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_NON_RETRYABLE_ERROR;
-import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_RETRYABLE_ERROR;
-import static devkor.com.teamcback.global.response.ResultCode.EXPO_PUSH_TICKET_ERROR;
 import static devkor.com.teamcback.global.response.ResultCode.FORBIDDEN_PUSH_INSTALLATION;
 import static devkor.com.teamcback.global.response.ResultCode.INACTIVE_PUSH_INSTALLATION;
 import static devkor.com.teamcback.global.response.ResultCode.INVALID_INPUT;
@@ -46,16 +39,11 @@ public class NotificationTestService {
     private static final int SCHEMA_VERSION = 1;
     private static final String TEST_TITLE = "고대로 테스트 알림";
     private static final String TEST_BODY = "푸시 알림 연결이 정상적으로 동작합니다.";
-    private static final String DEFAULT_SOUND = "default";
-    private static final String TICKET_STATUS_OK = "ok";
-    private static final String CLIENT_ERROR_STATUS = "client_error";
-    private static final String RETRYABLE_ERROR = "retryable";
 
     private final PushInstallationRepository pushInstallationRepository;
     private final PushDispatchRepository pushDispatchRepository;
     private final PushMessageRepository pushMessageRepository;
     private final PushPayloadFactory pushPayloadFactory;
-    private final ExpoPushClient expoPushClient;
     private final Clock clock;
 
     public NotificationTestRes sendTest(
@@ -72,26 +60,22 @@ public class NotificationTestService {
 
         return pushDispatchRepository.findByIdempotencyKey(idempotencyKey)
                 .map(dispatch -> responseFromExistingDispatch(dispatch, installation))
-                .orElseGet(() -> createAndSend(
+                .orElseGet(() -> enqueue(
                         userId,
                         idempotencyKey,
                         installation
                 ));
     }
 
-    private NotificationTestRes createAndSend(
+    private NotificationTestRes enqueue(
             Long userId,
             String idempotencyKey,
             PushInstallation installation
     ) {
-        String notificationId = UUID.randomUUID().toString();
         LocalDateTime now = LocalDateTime.now(clock);
 
-        PushDispatch dispatch;
-        PushMessage message;
-
         try {
-            dispatch = pushDispatchRepository.saveAndFlush(new PushDispatch(
+            PushDispatch dispatch = pushDispatchRepository.saveAndFlush(new PushDispatch(
                     NotificationType.GENERAL,
                     PushMode.TEST,
                     installation.getAppVariant(),
@@ -100,13 +84,13 @@ public class NotificationTestService {
                     TEST_TITLE,
                     TEST_BODY,
                     PushActionType.TEST,
-                    notificationId,
+                    pushPayloadFactory.serializeActionParams(Collections.emptyMap()),
                     idempotencyKey,
                     userId,
                     now
             ));
 
-            message = pushMessageRepository.saveAndFlush(new PushMessage(
+            PushMessage message = pushMessageRepository.saveAndFlush(new PushMessage(
                     dispatch,
                     installation,
                     now
@@ -114,58 +98,12 @@ public class NotificationTestService {
 
             dispatch.updateRecipientCount(1);
             pushDispatchRepository.save(dispatch);
+
+            return response(dispatch, message);
         } catch (DataIntegrityViolationException e) {
             return pushDispatchRepository.findByIdempotencyKey(idempotencyKey)
                     .map(dispatchFromRace -> responseFromExistingDispatch(dispatchFromRace, installation))
                     .orElseThrow(() -> new GlobalException(EXPO_PUSH_NON_RETRYABLE_ERROR));
-        }
-
-        try {
-            ExpoPushResponse response = expoPushClient.send(List.of(new ExpoPushRequest(
-                    installation.getExpoPushToken(),
-                    TEST_TITLE,
-                    TEST_BODY,
-                    DEFAULT_SOUND,
-                    pushPayloadFactory.create(
-                            notificationId,
-                            TEST_TITLE,
-                            TEST_BODY,
-                            PushMode.TEST,
-                            installation.getAppVariant(),
-                            PushActionType.TEST,
-                            Collections.emptyMap()
-                    ).data()
-            )));
-
-            ExpoPushTicket ticket = response.data().get(0);
-            message.recordTicket(
-                    ticket.status(),
-                    ticket.id(),
-                    ticket.details() == null ? null : ticket.details().error(),
-                    LocalDateTime.now(clock)
-            );
-            pushMessageRepository.save(message);
-
-            if (!TICKET_STATUS_OK.equals(ticket.status())) {
-                throw new GlobalException(EXPO_PUSH_TICKET_ERROR);
-            }
-
-            return new NotificationTestRes(
-                    notificationId,
-                    installation.getInstallationId(),
-                    installation.getAppVariant(),
-                    ticket.status(),
-                    ticket.id()
-            );
-        } catch (ExpoPushClientException e) {
-            message.recordClientError(
-                    e.isRetryable(),
-                    LocalDateTime.now(clock)
-            );
-            pushMessageRepository.save(message);
-            throw new GlobalException(e.isRetryable()
-                    ? EXPO_PUSH_RETRYABLE_ERROR
-                    : EXPO_PUSH_NON_RETRYABLE_ERROR);
         }
     }
 
@@ -185,25 +123,18 @@ public class NotificationTestService {
             throw new GlobalException(INVALID_INPUT);
         }
 
-        if (message.getTicketStatus() == null) {
-            throw new GlobalException(EXPO_PUSH_RETRYABLE_ERROR);
-        }
+        return response(dispatch, message);
+    }
 
-        if (CLIENT_ERROR_STATUS.equals(message.getTicketStatus())) {
-            throw new GlobalException(RETRYABLE_ERROR.equals(message.getTicketError())
-                    ? EXPO_PUSH_RETRYABLE_ERROR
-                    : EXPO_PUSH_NON_RETRYABLE_ERROR);
-        }
-
-        if (!TICKET_STATUS_OK.equals(message.getTicketStatus())) {
-            throw new GlobalException(EXPO_PUSH_TICKET_ERROR);
-        }
-
+    private NotificationTestRes response(
+            PushDispatch dispatch,
+            PushMessage message
+    ) {
         return new NotificationTestRes(
-                dispatch.getActionParams(),
+                String.valueOf(message.getPushMessageId()),
                 message.getInstallationId(),
                 dispatch.getAppVariant(),
-                message.getTicketStatus(),
+                message.getStatus(),
                 message.getExpoTicketId()
         );
     }

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimService.java
@@ -34,6 +34,7 @@ public class PushMessageClaimService {
     private static final String DEFAULT_SOUND = "default";
     private static final String TICKET_STATUS_ERROR = "error";
     private static final String RETRYABLE_TICKET_ERROR = "MessageRateExceeded";
+    private static final String DEVICE_NOT_REGISTERED_ERROR = "DeviceNotRegistered";
 
     private final PushMessageRepository pushMessageRepository;
     private final PushInstallationRepository pushInstallationRepository;
@@ -91,7 +92,16 @@ public class PushMessageClaimService {
 
             ExpoPushTicket ticket = tickets == null || i >= tickets.size() ? null : tickets.get(i);
             String ticketError = ticketError(ticket);
-            if (isRetryableTicket(ticket)) {
+            if (isDeviceNotRegisteredTicket(ticket)) {
+                message.recordTicket(
+                        ticket.status(),
+                        ticket.id(),
+                        ticketError,
+                        now
+                );
+                pushInstallationRepository.findById(message.getPushInstallationId())
+                        .ifPresent(installation -> installation.deactivate(now));
+            } else if (isRetryableTicket(ticket)) {
                 message.recordRetryableTicketError(
                         ticket.status(),
                         ticketError,
@@ -237,11 +247,11 @@ public class PushMessageClaimService {
                             new EnumMap<>(PushMessageStatus.class)
                     );
                     dispatch.updateStatusFromMessageSummary(
-                            count(counts, PushMessageStatus.QUEUED),
+                            count(counts, PushMessageStatus.QUEUED)
+                                    + count(counts, PushMessageStatus.TICKET_RECEIVED)
+                                    + count(counts, PushMessageStatus.RECEIPT_PENDING),
                             count(counts, PushMessageStatus.SENDING),
-                            count(counts, PushMessageStatus.TICKET_RECEIVED)
-                                    + count(counts, PushMessageStatus.RECEIPT_PENDING)
-                                    + count(counts, PushMessageStatus.DELIVERED),
+                            count(counts, PushMessageStatus.DELIVERED),
                             count(counts, PushMessageStatus.FAILED),
                             now
                     );
@@ -259,6 +269,13 @@ public class PushMessageClaimService {
         return ticket != null
                 && TICKET_STATUS_ERROR.equals(ticket.status())
                 && RETRYABLE_TICKET_ERROR.equals(ticketError(ticket));
+    }
+
+    private boolean isDeviceNotRegisteredTicket(ExpoPushTicket ticket) {
+        return ticket != null
+                && TICKET_STATUS_ERROR.equals(ticket.status())
+                && ticket.details() != null
+                && DEVICE_NOT_REGISTERED_ERROR.equals(ticket.details().error());
     }
 
     private String ticketError(ExpoPushTicket ticket) {

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimService.java
@@ -1,0 +1,282 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushWorkerProperties;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushRequest;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushTicket;
+import devkor.com.teamcback.domain.notification.dto.payload.PushPayload;
+import devkor.com.teamcback.domain.notification.dto.worker.PushSendItem;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PushMessageClaimService {
+
+    private static final String DEFAULT_SOUND = "default";
+    private static final String TICKET_STATUS_ERROR = "error";
+    private static final String RETRYABLE_TICKET_ERROR = "MessageRateExceeded";
+
+    private final PushMessageRepository pushMessageRepository;
+    private final PushInstallationRepository pushInstallationRepository;
+    private final PushDispatchRepository pushDispatchRepository;
+    private final PushPayloadFactory pushPayloadFactory;
+    private final PushWorkerProperties pushWorkerProperties;
+    private final Clock clock;
+
+    @Transactional
+    public List<PushSendItem> claimDueMessages() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<PushMessage> messages = pushMessageRepository.findDueQueuedForUpdateSkipLocked(
+                now,
+                pushWorkerProperties.batchSize()
+        );
+
+        if (messages.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> dispatchIds = new HashSet<>();
+        List<PushSendItem> sendItems = messages.stream()
+                .peek(message -> {
+                    message.markSending(now);
+                    dispatchIds.add(message.getDispatch().getPushDispatchId());
+                })
+                .map(message -> createSendItem(message, now))
+                .filter(item -> item != null)
+                .toList();
+
+        refreshDispatchStatuses(dispatchIds, now);
+        return sendItems;
+    }
+
+    @Transactional
+    public void recordTickets(
+            List<PushSendItem> items,
+            List<ExpoPushTicket> tickets
+    ) {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime nextRetryAt = now.plusNanos(pushWorkerProperties.retryDelayMs() * 1_000_000L);
+        Map<Long, PushMessage> messageMap = findMessageMap(items);
+        Set<Long> dispatchIds = new HashSet<>();
+
+        for (int i = 0; i < items.size(); i += 1) {
+            PushSendItem item = items.get(i);
+            PushMessage message = messageMap.get(item.pushMessageId());
+            if (message == null) {
+                continue;
+            }
+
+            ExpoPushTicket ticket = tickets == null || i >= tickets.size() ? null : tickets.get(i);
+            String ticketError = ticketError(ticket);
+            if (isRetryableTicket(ticket)) {
+                message.recordRetryableTicketError(
+                        ticket.status(),
+                        ticketError,
+                        pushWorkerProperties.maxSendAttempts(),
+                        nextRetryAt,
+                        now
+                );
+            } else {
+                message.recordTicket(
+                        ticket == null ? "missing_ticket" : ticket.status(),
+                        ticket == null ? null : ticket.id(),
+                        ticketError,
+                        now
+                );
+            }
+            dispatchIds.add(item.pushDispatchId());
+        }
+
+        refreshDispatchStatuses(dispatchIds, now);
+    }
+
+    @Transactional
+    public void recordClientError(
+            List<PushSendItem> items,
+            boolean retryable,
+            String ticketError
+    ) {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime nextRetryAt = now.plusNanos(pushWorkerProperties.retryDelayMs() * 1_000_000L);
+        Map<Long, PushMessage> messageMap = findMessageMap(items);
+        Set<Long> dispatchIds = new HashSet<>();
+
+        items.forEach(item -> {
+            PushMessage message = messageMap.get(item.pushMessageId());
+            if (message == null) {
+                return;
+            }
+            message.recordClientError(
+                    retryable,
+                    truncate(ticketError),
+                    pushWorkerProperties.maxSendAttempts(),
+                    nextRetryAt,
+                    now
+            );
+            dispatchIds.add(item.pushDispatchId());
+        });
+
+        refreshDispatchStatuses(dispatchIds, now);
+    }
+
+    private PushSendItem createSendItem(
+            PushMessage message,
+            LocalDateTime now
+    ) {
+        PushDispatch dispatch = message.getDispatch();
+        PushInstallation installation = pushInstallationRepository
+                .findByPushInstallationIdAndInstallationIdAndAppVariantAndActiveTrue(
+                        message.getPushInstallationId(),
+                        message.getInstallationId(),
+                        dispatch.getAppVariant()
+                )
+                .orElse(null);
+
+        if (installation == null) {
+            message.recordSkipped(
+                    "installation_inactive",
+                    "inactive_or_variant_mismatch",
+                    now
+            );
+            return null;
+        }
+
+        try {
+            PushPayload payload = pushPayloadFactory.create(
+                    String.valueOf(message.getPushMessageId()),
+                    dispatch.getTitle(),
+                    dispatch.getBody(),
+                    dispatch.getMode(),
+                    dispatch.getAppVariant(),
+                    dispatch.getActionType(),
+                    pushPayloadFactory.deserializeActionParams(dispatch.getActionParams())
+            );
+
+            return new PushSendItem(
+                    message.getPushMessageId(),
+                    dispatch.getPushDispatchId(),
+                    new ExpoPushRequest(
+                            installation.getExpoPushToken(),
+                            payload.title(),
+                            payload.body(),
+                            DEFAULT_SOUND,
+                            payload.data()
+                    )
+            );
+        } catch (RuntimeException e) {
+            message.recordSkipped(
+                    "invalid_payload",
+                    "payload_validation_failed",
+                    now
+            );
+            return null;
+        }
+    }
+
+    private Map<Long, PushMessage> findMessageMap(List<PushSendItem> items) {
+        List<Long> messageIds = items.stream()
+                .map(PushSendItem::pushMessageId)
+                .toList();
+
+        return pushMessageRepository.findAllByPushMessageIdIn(messageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PushMessage::getPushMessageId,
+                        message -> message
+                ));
+    }
+
+    private void refreshDispatchStatuses(
+            Collection<Long> dispatchIds,
+            LocalDateTime now
+    ) {
+        if (dispatchIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, EnumMap<PushMessageStatus, Long>> countsByDispatchId = new HashMap<>();
+        pushMessageRepository.countStatusesByDispatchIds(dispatchIds)
+                .forEach(count -> countsByDispatchId
+                        .computeIfAbsent(
+                                count.getDispatchId(),
+                                ignored -> new EnumMap<>(PushMessageStatus.class)
+                        )
+                        .put(count.getStatus(), count.getCount()));
+
+        pushDispatchRepository.findAllById(dispatchIds)
+                .forEach(dispatch -> {
+                    EnumMap<PushMessageStatus, Long> counts = countsByDispatchId.getOrDefault(
+                            dispatch.getPushDispatchId(),
+                            new EnumMap<>(PushMessageStatus.class)
+                    );
+                    dispatch.updateStatusFromMessageSummary(
+                            count(counts, PushMessageStatus.QUEUED),
+                            count(counts, PushMessageStatus.SENDING),
+                            count(counts, PushMessageStatus.TICKET_RECEIVED)
+                                    + count(counts, PushMessageStatus.RECEIPT_PENDING)
+                                    + count(counts, PushMessageStatus.DELIVERED),
+                            count(counts, PushMessageStatus.FAILED),
+                            now
+                    );
+                });
+    }
+
+    private long count(
+            EnumMap<PushMessageStatus, Long> counts,
+            PushMessageStatus status
+    ) {
+        return counts.getOrDefault(status, 0L);
+    }
+
+    private boolean isRetryableTicket(ExpoPushTicket ticket) {
+        return ticket != null
+                && TICKET_STATUS_ERROR.equals(ticket.status())
+                && RETRYABLE_TICKET_ERROR.equals(ticketError(ticket));
+    }
+
+    private String ticketError(ExpoPushTicket ticket) {
+        if (ticket == null) {
+            return "missing_ticket";
+        }
+
+        if (ticket.details() != null && ticket.details().error() != null) {
+            return truncate(ticket.details().error());
+        }
+
+        return truncate(ticket.message());
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.length() <= 1024) {
+            return value;
+        }
+        return value.substring(0, 1024);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageDispatchWorker.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageDispatchWorker.java
@@ -1,0 +1,47 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.client.ExpoPushClient;
+import devkor.com.teamcback.domain.notification.client.ExpoPushClientException;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushResponse;
+import devkor.com.teamcback.domain.notification.dto.worker.PushSendItem;
+import devkor.com.teamcback.domain.notification.dto.worker.PushWorkerDispatchResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushMessageDispatchWorker {
+
+    private final PushMessageClaimService pushMessageClaimService;
+    private final ExpoPushClient expoPushClient;
+
+    public PushWorkerDispatchResult dispatchPending() {
+        List<PushSendItem> items = pushMessageClaimService.claimDueMessages();
+        if (items.isEmpty()) {
+            return PushWorkerDispatchResult.empty();
+        }
+
+        try {
+            ExpoPushResponse response = expoPushClient.send(items.stream()
+                    .map(PushSendItem::request)
+                    .toList());
+            pushMessageClaimService.recordTickets(items, response.data());
+            return new PushWorkerDispatchResult(items.size(), items.size());
+        } catch (ExpoPushClientException e) {
+            pushMessageClaimService.recordClientError(
+                    items,
+                    e.isRetryable(),
+                    e.getHttpStatus() == null ? e.getMessage() : "http_" + e.getHttpStatus()
+            );
+            log.warn(
+                    "Expo push send failed. retryable={}, itemCount={}",
+                    e.isRetryable(),
+                    items.size()
+            );
+            return new PushWorkerDispatchResult(items.size(), 0);
+        }
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryService.java
@@ -1,0 +1,112 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushRecoveryWorkerProperties;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PushMessageRecoveryService {
+
+    private static final String WORKER_INTERRUPTED = "worker_interrupted";
+
+    private final PushMessageRepository pushMessageRepository;
+    private final PushDispatchRepository pushDispatchRepository;
+    private final PushRecoveryWorkerProperties pushRecoveryWorkerProperties;
+    private final Clock clock;
+
+    @Transactional
+    public int recoverStaleSendingMessages() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime staleBefore = now.minusMinutes(pushRecoveryWorkerProperties.staleThresholdMinutes());
+        List<PushMessage> messages = pushMessageRepository.findStaleSendingForUpdateSkipLocked(
+                staleBefore,
+                pushRecoveryWorkerProperties.batchSize()
+        );
+
+        if (messages.isEmpty()) {
+            return 0;
+        }
+
+        Set<Long> dispatchIds = new HashSet<>();
+        messages.forEach(message -> {
+            dispatchIds.add(message.getDispatch().getPushDispatchId());
+            if (hasText(message.getExpoTicketId())) {
+                message.recoverInterruptedSendingWithTicket(now);
+                return;
+            }
+            message.recoverInterruptedSendingWithoutTicket(WORKER_INTERRUPTED, now);
+        });
+
+        refreshDispatchStatuses(dispatchIds, now);
+        return messages.size();
+    }
+
+    private void refreshDispatchStatuses(
+            Collection<Long> dispatchIds,
+            LocalDateTime now
+    ) {
+        if (dispatchIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, EnumMap<PushMessageStatus, Long>> countsByDispatchId = new HashMap<>();
+        pushMessageRepository.countStatusesByDispatchIds(dispatchIds)
+                .forEach(count -> countsByDispatchId
+                        .computeIfAbsent(
+                                count.getDispatchId(),
+                                ignored -> new EnumMap<>(PushMessageStatus.class)
+                        )
+                        .put(count.getStatus(), count.getCount()));
+
+        pushDispatchRepository.findAllById(dispatchIds)
+                .forEach(dispatch -> updateDispatchStatus(dispatch, countsByDispatchId, now));
+    }
+
+    private void updateDispatchStatus(
+            PushDispatch dispatch,
+            Map<Long, EnumMap<PushMessageStatus, Long>> countsByDispatchId,
+            LocalDateTime now
+    ) {
+        EnumMap<PushMessageStatus, Long> counts = countsByDispatchId.getOrDefault(
+                dispatch.getPushDispatchId(),
+                new EnumMap<>(PushMessageStatus.class)
+        );
+
+        dispatch.updateStatusFromMessageSummary(
+                count(counts, PushMessageStatus.QUEUED)
+                        + count(counts, PushMessageStatus.TICKET_RECEIVED)
+                        + count(counts, PushMessageStatus.RECEIPT_PENDING),
+                count(counts, PushMessageStatus.SENDING),
+                count(counts, PushMessageStatus.DELIVERED),
+                count(counts, PushMessageStatus.FAILED),
+                now
+        );
+    }
+
+    private long count(
+            EnumMap<PushMessageStatus, Long> counts,
+            PushMessageStatus status
+    ) {
+        return counts.getOrDefault(status, 0L);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryWorker.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryWorker.java
@@ -1,0 +1,21 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushMessageRecoveryWorker {
+
+    private final PushMessageRecoveryService pushMessageRecoveryService;
+
+    public int recoverStaleSendingMessages() {
+        int recoveredCount = pushMessageRecoveryService.recoverStaleSendingMessages();
+        if (recoveredCount > 0) {
+            log.warn("Recovered stale SENDING push messages. count={}", recoveredCount);
+        }
+        return recoveredCount;
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushReceiptClaimService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushReceiptClaimService.java
@@ -1,0 +1,281 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushReceiptWorkerProperties;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushReceipt;
+import devkor.com.teamcback.domain.notification.dto.worker.PushReceiptItem;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PushReceiptClaimService {
+
+    private static final String RECEIPT_STATUS_OK = "ok";
+    private static final String RECEIPT_STATUS_ERROR = "error";
+    private static final String RECEIPT_STATUS_NOT_READY = "not_ready";
+    private static final String CLIENT_ERROR_STATUS = "client_error";
+    private static final String DEVICE_NOT_REGISTERED_ERROR = "DeviceNotRegistered";
+
+    private final PushMessageRepository pushMessageRepository;
+    private final PushInstallationRepository pushInstallationRepository;
+    private final PushDispatchRepository pushDispatchRepository;
+    private final PushReceiptWorkerProperties pushReceiptWorkerProperties;
+    private final Clock clock;
+
+    @Transactional
+    public List<PushReceiptItem> claimDueReceipts() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<PushMessage> messages = pushMessageRepository.findDueReceiptPendingForUpdateSkipLocked(
+                now,
+                pushReceiptWorkerProperties.batchSize()
+        );
+
+        if (messages.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> dispatchIds = new HashSet<>();
+        List<PushReceiptItem> receiptItems = messages.stream()
+                .map(message -> claimMessage(message, now, dispatchIds))
+                .filter(item -> item != null)
+                .toList();
+
+        refreshDispatchStatuses(dispatchIds, now);
+        return receiptItems;
+    }
+
+    @Transactional
+    public void recordReceipts(
+            List<PushReceiptItem> items,
+            Map<String, ExpoPushReceipt> receiptMap
+    ) {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        Map<Long, PushMessage> messageMap = findMessageMap(items);
+        Set<Long> dispatchIds = new HashSet<>();
+
+        for (PushReceiptItem item : items) {
+            PushMessage message = messageMap.get(item.pushMessageId());
+            if (message == null) {
+                continue;
+            }
+
+            ExpoPushReceipt receipt = receiptMap == null ? null : receiptMap.get(item.expoTicketId());
+            if (receipt == null) {
+                scheduleRetry(message, RECEIPT_STATUS_NOT_READY, "receipt_not_ready", now);
+            } else if (isDeviceNotRegisteredReceipt(receipt)) {
+                message.recordReceipt(
+                        receipt.status(),
+                        receiptError(receipt),
+                        now
+                );
+                pushInstallationRepository.findById(message.getPushInstallationId())
+                        .ifPresent(installation -> installation.deactivate(now));
+            } else {
+                message.recordReceipt(
+                        receipt.status(),
+                        receiptError(receipt),
+                        now
+                );
+            }
+            dispatchIds.add(item.pushDispatchId());
+        }
+
+        refreshDispatchStatuses(dispatchIds, now);
+    }
+
+    @Transactional
+    public void recordClientError(
+            List<PushReceiptItem> items,
+            boolean retryable,
+            String receiptError
+    ) {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        Map<Long, PushMessage> messageMap = findMessageMap(items);
+        Set<Long> dispatchIds = new HashSet<>();
+
+        items.forEach(item -> {
+            PushMessage message = messageMap.get(item.pushMessageId());
+            if (message == null) {
+                return;
+            }
+            if (retryable) {
+                scheduleRetry(message, CLIENT_ERROR_STATUS, truncate(receiptError), now);
+            } else {
+                message.recordReceipt(
+                        CLIENT_ERROR_STATUS,
+                        truncate(receiptError),
+                        now
+                );
+            }
+            dispatchIds.add(item.pushDispatchId());
+        });
+
+        refreshDispatchStatuses(dispatchIds, now);
+    }
+
+    private PushReceiptItem claimMessage(
+            PushMessage message,
+            LocalDateTime now,
+            Set<Long> dispatchIds
+    ) {
+        dispatchIds.add(message.getDispatch().getPushDispatchId());
+
+        if (isReceiptExpired(message, now)) {
+            message.recordReceiptExpired(now);
+            return null;
+        }
+
+        message.markReceiptChecking(now);
+        return new PushReceiptItem(
+                message.getPushMessageId(),
+                message.getDispatch().getPushDispatchId(),
+                message.getExpoTicketId()
+        );
+    }
+
+    private void scheduleRetry(
+            PushMessage message,
+            String receiptStatus,
+            String receiptError,
+            LocalDateTime now
+    ) {
+        if (isReceiptExpired(message, now)) {
+            message.recordReceiptExpired(now);
+            return;
+        }
+
+        message.scheduleReceiptRetry(
+                receiptStatus,
+                receiptError,
+                pushReceiptWorkerProperties.maxReceiptAttempts(),
+                now.plusMinutes(nextBackoffMinutes(message.getReceiptAttempts())),
+                now
+        );
+    }
+
+    private long nextBackoffMinutes(int currentReceiptAttempts) {
+        int retryNumber = Math.max(0, currentReceiptAttempts);
+        return 1L << Math.min(retryNumber, 2);
+    }
+
+    private boolean isReceiptExpired(
+            PushMessage message,
+            LocalDateTime now
+    ) {
+        return message.getSentAt() == null
+                || message.getSentAt().plusHours(24).isBefore(now);
+    }
+
+    private Map<Long, PushMessage> findMessageMap(List<PushReceiptItem> items) {
+        List<Long> messageIds = items.stream()
+                .map(PushReceiptItem::pushMessageId)
+                .toList();
+
+        return pushMessageRepository.findAllByPushMessageIdIn(messageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PushMessage::getPushMessageId,
+                        message -> message
+                ));
+    }
+
+    private void refreshDispatchStatuses(
+            Collection<Long> dispatchIds,
+            LocalDateTime now
+    ) {
+        if (dispatchIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, EnumMap<PushMessageStatus, Long>> countsByDispatchId = new HashMap<>();
+        pushMessageRepository.countStatusesByDispatchIds(dispatchIds)
+                .forEach(count -> countsByDispatchId
+                        .computeIfAbsent(
+                                count.getDispatchId(),
+                                ignored -> new EnumMap<>(PushMessageStatus.class)
+                        )
+                        .put(count.getStatus(), count.getCount()));
+
+        pushDispatchRepository.findAllById(dispatchIds)
+                .forEach(dispatch -> updateDispatchStatus(dispatch, countsByDispatchId, now));
+    }
+
+    private void updateDispatchStatus(
+            PushDispatch dispatch,
+            Map<Long, EnumMap<PushMessageStatus, Long>> countsByDispatchId,
+            LocalDateTime now
+    ) {
+        EnumMap<PushMessageStatus, Long> counts = countsByDispatchId.getOrDefault(
+                dispatch.getPushDispatchId(),
+                new EnumMap<>(PushMessageStatus.class)
+        );
+
+        dispatch.updateStatusFromMessageSummary(
+                count(counts, PushMessageStatus.QUEUED)
+                        + count(counts, PushMessageStatus.TICKET_RECEIVED)
+                        + count(counts, PushMessageStatus.RECEIPT_PENDING),
+                count(counts, PushMessageStatus.SENDING),
+                count(counts, PushMessageStatus.DELIVERED),
+                count(counts, PushMessageStatus.FAILED),
+                now
+        );
+    }
+
+    private long count(
+            EnumMap<PushMessageStatus, Long> counts,
+            PushMessageStatus status
+    ) {
+        return counts.getOrDefault(status, 0L);
+    }
+
+    private boolean isDeviceNotRegisteredReceipt(ExpoPushReceipt receipt) {
+        return receipt != null
+                && RECEIPT_STATUS_ERROR.equals(receipt.status())
+                && receipt.details() != null
+                && DEVICE_NOT_REGISTERED_ERROR.equals(receipt.details().error());
+    }
+
+    private String receiptError(ExpoPushReceipt receipt) {
+        if (receipt == null || RECEIPT_STATUS_OK.equals(receipt.status())) {
+            return null;
+        }
+
+        if (receipt.details() != null && receipt.details().error() != null) {
+            return truncate(receipt.details().error());
+        }
+
+        return truncate(receipt.message());
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.length() <= 1024) {
+            return value;
+        }
+        return value.substring(0, 1024);
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/PushReceiptWorker.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/PushReceiptWorker.java
@@ -1,0 +1,47 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.client.ExpoPushClient;
+import devkor.com.teamcback.domain.notification.client.ExpoPushClientException;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoReceiptResponse;
+import devkor.com.teamcback.domain.notification.dto.worker.PushReceiptItem;
+import devkor.com.teamcback.domain.notification.dto.worker.PushReceiptWorkerResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushReceiptWorker {
+
+    private final PushReceiptClaimService pushReceiptClaimService;
+    private final ExpoPushClient expoPushClient;
+
+    public PushReceiptWorkerResult checkPendingReceipts() {
+        List<PushReceiptItem> items = pushReceiptClaimService.claimDueReceipts();
+        if (items.isEmpty()) {
+            return PushReceiptWorkerResult.empty();
+        }
+
+        try {
+            ExpoReceiptResponse response = expoPushClient.getReceipts(items.stream()
+                    .map(PushReceiptItem::expoTicketId)
+                    .toList());
+            pushReceiptClaimService.recordReceipts(items, response.data());
+            return new PushReceiptWorkerResult(items.size(), items.size());
+        } catch (ExpoPushClientException e) {
+            pushReceiptClaimService.recordClientError(
+                    items,
+                    e.isRetryable(),
+                    e.getHttpStatus() == null ? e.getMessage() : "http_" + e.getHttpStatus()
+            );
+            log.warn(
+                    "Expo push receipt request failed. retryable={}, itemCount={}",
+                    e.isRetryable(),
+                    items.size()
+            );
+            return new PushReceiptWorkerResult(items.size(), 0);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,3 +165,8 @@ push:
     batch-size: ${PUSH_WORKER_BATCH_SIZE:100}
     max-send-attempts: ${PUSH_WORKER_MAX_SEND_ATTEMPTS:3}
     retry-delay-ms: ${PUSH_WORKER_RETRY_DELAY_MS:30000}
+  receipt-worker:
+    enabled: ${PUSH_RECEIPT_WORKER_ENABLED:false}
+    fixed-delay-ms: ${PUSH_RECEIPT_WORKER_FIXED_DELAY_MS:60000}
+    batch-size: ${PUSH_RECEIPT_WORKER_BATCH_SIZE:1000}
+    max-receipt-attempts: ${PUSH_RECEIPT_WORKER_MAX_RECEIPT_ATTEMPTS:3}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,3 +170,8 @@ push:
     fixed-delay-ms: ${PUSH_RECEIPT_WORKER_FIXED_DELAY_MS:60000}
     batch-size: ${PUSH_RECEIPT_WORKER_BATCH_SIZE:1000}
     max-receipt-attempts: ${PUSH_RECEIPT_WORKER_MAX_RECEIPT_ATTEMPTS:3}
+  recovery-worker:
+    enabled: ${PUSH_RECOVERY_WORKER_ENABLED:false}
+    cron: ${PUSH_RECOVERY_WORKER_CRON:0 0 4 * * *}
+    stale-threshold-minutes: ${PUSH_RECOVERY_STALE_THRESHOLD_MINUTES:30}
+    batch-size: ${PUSH_RECOVERY_BATCH_SIZE:100}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,3 +159,9 @@ push:
     access-token: ${EXPO_ACCESS_TOKEN:}
     connect-timeout: 3s
     read-timeout: 10s
+  worker:
+    enabled: ${PUSH_WORKER_ENABLED:false}
+    fixed-delay-ms: ${PUSH_WORKER_FIXED_DELAY_MS:5000}
+    batch-size: ${PUSH_WORKER_BATCH_SIZE:100}
+    max-send-attempts: ${PUSH_WORKER_MAX_SEND_ATTEMPTS:3}
+    retry-delay-ms: ${PUSH_WORKER_RETRY_DELAY_MS:30000}

--- a/src/main/resources/db/migration/V20260804_01__add_push_message_receipt_available_at.sql
+++ b/src/main/resources/db/migration/V20260804_01__add_push_message_receipt_available_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_push_message
+    ADD COLUMN receipt_available_at datetime(6) NULL AFTER sent_at;

--- a/src/main/resources/db/migration/V20260804_01__add_push_message_receipt_available_at.sql
+++ b/src/main/resources/db/migration/V20260804_01__add_push_message_receipt_available_at.sql
@@ -1,2 +1,0 @@
-ALTER TABLE tb_push_message
-    ADD COLUMN receipt_available_at datetime(6) NULL AFTER sent_at;

--- a/src/test/java/devkor/com/teamcback/domain/notification/PushNotificationPipelineIntegrationTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/PushNotificationPipelineIntegrationTest.java
@@ -1,0 +1,342 @@
+package devkor.com.teamcback.domain.notification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import devkor.com.teamcback.domain.notification.dto.request.NotificationTestReq;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import devkor.com.teamcback.domain.notification.service.NotificationTestService;
+import devkor.com.teamcback.domain.notification.service.PushMessageDispatchWorker;
+import devkor.com.teamcback.domain.notification.service.PushReceiptWorker;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.redisson.api.RedissonClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.url=jdbc:h2:mem:push_pipeline;MODE=MySQL;DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=YEAR,END;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.sql.init.mode=never",
+        "spring.cache.type=simple",
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.data.redis.password=test",
+        "push.worker.enabled=false",
+        "push.receipt-worker.enabled=false",
+        "jwt.secret.key=MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+        "jwt.admin.token=test-admin-token",
+        "jwt.social.kakao.iss=test-kakao-iss",
+        "jwt.social.kakao.aud=test-kakao-aud",
+        "jwt.social.google.iss=test-google-iss",
+        "jwt.social.google.aud=test-google-aud",
+        "jwt.social.apple.iss=test-apple-iss",
+        "jwt.social.apple.aud=test-apple-aud",
+        "jwt.social.apple.dev-aud=test-apple-dev-aud",
+        "metrics.environment=test",
+        "staff.emails=test@example.com",
+        "cloud.aws.s3.bucket=test-bucket",
+        "cloud.aws.credentials.access-key=test-access-key",
+        "cloud.aws.credentials.secret-key=test-secret-key",
+        "cloud.aws.region.static=ap-northeast-2",
+        "date.api.holiday.end-point=http://localhost",
+        "date.api.holiday.encoded-key=test-encoded-key",
+        "date.api.holiday.decoded-key=test-decoded-key",
+        "spring.mail.host=localhost",
+        "management.health.mail.enabled=false"
+})
+class PushNotificationPipelineIntegrationTest {
+
+    private static final String EXPO_PUSH_TOKEN = "ExponentPushToken[pipeline-test-token]";
+    private static final String TICKET_ID = "ticket-pipeline-1";
+    private static final MockExpoServer EXPO_SERVER = new MockExpoServer();
+
+    @Autowired
+    private NotificationTestService notificationTestService;
+
+    @Autowired
+    private PushMessageDispatchWorker pushMessageDispatchWorker;
+
+    @Autowired
+    private PushReceiptWorker pushReceiptWorker;
+
+    @Autowired
+    private PushInstallationRepository pushInstallationRepository;
+
+    @Autowired
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Autowired
+    private PushMessageRepository pushMessageRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private RedissonClient redissonClient;
+
+    @DynamicPropertySource
+    static void expoProperties(DynamicPropertyRegistry registry) {
+        EXPO_SERVER.start();
+        registry.add("push.expo.base-url", EXPO_SERVER::baseUrl);
+    }
+
+    @AfterAll
+    static void stopExpoServer() {
+        EXPO_SERVER.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        EXPO_SERVER.reset();
+        pushMessageRepository.deleteAll();
+        pushDispatchRepository.deleteAll();
+        pushInstallationRepository.deleteAll();
+    }
+
+    @Test
+    void testNotificationPipelineQueuesSendsReceiptsAndCompletesDispatch() throws Exception {
+        PushInstallation installation = pushInstallationRepository.save(new PushInstallation(
+                1L,
+                "install-pipeline",
+                EXPO_PUSH_TOKEN,
+                AppVariant.DEV
+        ));
+
+        notificationTestService.sendTest(
+                1L,
+                UUID.randomUUID().toString(),
+                new NotificationTestReq(1, installation.getInstallationId())
+        );
+
+        List<PushDispatch> dispatches = pushDispatchRepository.findAll();
+        List<PushMessage> messages = pushMessageRepository.findAll();
+        assertThat(dispatches).hasSize(1);
+        assertThat(messages).hasSize(1);
+
+        PushDispatch dispatch = dispatches.get(0);
+        PushMessage queuedMessage = messages.get(0);
+        assertThat(dispatch.getRecipientCount()).isEqualTo(1);
+        assertThat(queuedMessage.getStatus()).isEqualTo(PushMessageStatus.QUEUED);
+        assertThat(EXPO_SERVER.requests()).isEmpty();
+
+        EXPO_SERVER.enqueueJson(200, """
+                {"data":[{"status":"ok","id":"ticket-pipeline-1"}]}
+                """);
+        pushMessageDispatchWorker.dispatchPending();
+
+        PushMessage receiptPendingMessage = pushMessageRepository.findById(queuedMessage.getPushMessageId()).orElseThrow();
+        assertThat(receiptPendingMessage.getStatus()).isEqualTo(PushMessageStatus.RECEIPT_PENDING);
+        assertThat(receiptPendingMessage.getExpoTicketId()).isEqualTo(TICKET_ID);
+        assertThat(receiptPendingMessage.getReceiptAvailableAt()).isNotNull();
+
+        RecordedRequest sendRequest = EXPO_SERVER.takeOnlyRequest();
+        assertThat(sendRequest.path()).isEqualTo("/send");
+        JsonNode sendBody = objectMapper.readTree(sendRequest.body());
+        JsonNode firstSend = sendBody.get(0);
+        assertThat(firstSend.get("to").asText()).isEqualTo(EXPO_PUSH_TOKEN);
+        assertThat(firstSend.at("/data/action/type").asText()).isEqualTo(PushActionType.TEST.name());
+        assertThat(firstSend.at("/data/notificationId").asText())
+                .isEqualTo(String.valueOf(receiptPendingMessage.getPushMessageId()));
+
+        ReflectionTestUtils.setField(
+                receiptPendingMessage,
+                "receiptAvailableAt",
+                LocalDateTime.now().minusMinutes(1)
+        );
+        pushMessageRepository.saveAndFlush(receiptPendingMessage);
+
+        EXPO_SERVER.reset();
+        EXPO_SERVER.enqueueJson(200, """
+                {"data":{"ticket-pipeline-1":{"status":"ok"}}}
+                """);
+        pushReceiptWorker.checkPendingReceipts();
+
+        PushMessage deliveredMessage = pushMessageRepository.findById(queuedMessage.getPushMessageId()).orElseThrow();
+        PushDispatch completedDispatch = pushDispatchRepository.findById(dispatch.getPushDispatchId()).orElseThrow();
+        assertThat(deliveredMessage.getStatus()).isEqualTo(PushMessageStatus.DELIVERED);
+        assertThat(deliveredMessage.getReceiptStatus()).isEqualTo("ok");
+        assertThat(deliveredMessage.getReceiptCheckedAt()).isNotNull();
+        assertThat(completedDispatch.getStatus()).isEqualTo(PushDispatchStatus.COMPLETED);
+        assertThat(pushMessageRepository.findById(deliveredMessage.getPushMessageId())).isPresent();
+        assertThat(pushDispatchRepository.findById(completedDispatch.getPushDispatchId())).isPresent();
+
+        RecordedRequest receiptRequest = EXPO_SERVER.takeOnlyRequest();
+        assertThat(receiptRequest.path()).isEqualTo("/getReceipts");
+        JsonNode receiptBody = objectMapper.readTree(receiptRequest.body());
+        JsonNode ids = receiptBody.get("ids");
+        assertThat(ids)
+                .as("receipt request body: " + receiptRequest.body())
+                .isNotNull();
+        assertThat(ids.isArray()).isTrue();
+        assertThat(ids.get(0).asText()).isEqualTo(TICKET_ID);
+    }
+
+    @Test
+    void receiptDeviceNotRegisteredFailsMessageAndDeactivatesInstallation() {
+        PushInstallation installation = pushInstallationRepository.save(new PushInstallation(
+                1L,
+                "install-device-not-registered",
+                EXPO_PUSH_TOKEN,
+                AppVariant.DEV
+        ));
+
+        notificationTestService.sendTest(
+                1L,
+                UUID.randomUUID().toString(),
+                new NotificationTestReq(1, installation.getInstallationId())
+        );
+
+        EXPO_SERVER.enqueueJson(200, """
+                {"data":[{"status":"ok","id":"ticket-pipeline-1"}]}
+                """);
+        pushMessageDispatchWorker.dispatchPending();
+
+        PushMessage receiptPendingMessage = pushMessageRepository.findAll().get(0);
+        ReflectionTestUtils.setField(
+                receiptPendingMessage,
+                "receiptAvailableAt",
+                LocalDateTime.now().minusMinutes(1)
+        );
+        pushMessageRepository.saveAndFlush(receiptPendingMessage);
+
+        EXPO_SERVER.reset();
+        EXPO_SERVER.enqueueJson(200, """
+                {"data":{"ticket-pipeline-1":{"status":"error","details":{"error":"DeviceNotRegistered"}}}}
+                """);
+        pushReceiptWorker.checkPendingReceipts();
+
+        PushMessage failedMessage = pushMessageRepository.findById(receiptPendingMessage.getPushMessageId()).orElseThrow();
+        PushInstallation deactivatedInstallation = pushInstallationRepository.findById(installation.getPushInstallationId())
+                .orElseThrow();
+        PushDispatch failedDispatch = pushDispatchRepository.findAll().get(0);
+
+        assertThat(failedMessage.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(failedMessage.getReceiptStatus()).isEqualTo("error");
+        assertThat(failedMessage.getReceiptError()).isEqualTo("DeviceNotRegistered");
+        assertThat(deactivatedInstallation.isActive()).isFalse();
+        assertThat(failedDispatch.getStatus()).isEqualTo(PushDispatchStatus.FAILED);
+    }
+
+    private record RecordedRequest(String path, String body) {
+    }
+
+    private static final class MockExpoServer {
+
+        private final ConcurrentLinkedQueue<String> responses = new ConcurrentLinkedQueue<>();
+        private final List<RecordedRequest> requests = new ArrayList<>();
+        private HttpServer server;
+
+        void start() {
+            if (server != null) {
+                return;
+            }
+
+            try {
+                server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+
+            server.createContext("/", this::handle);
+            server.start();
+        }
+
+        void stop() {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
+
+        String baseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        void reset() {
+            responses.clear();
+            synchronized (requests) {
+                requests.clear();
+            }
+        }
+
+        void enqueueJson(
+                int status,
+                String body
+        ) {
+            responses.add(status + "\n" + body);
+        }
+
+        List<RecordedRequest> requests() {
+            synchronized (requests) {
+                return List.copyOf(requests);
+            }
+        }
+
+        RecordedRequest takeOnlyRequest() {
+            List<RecordedRequest> snapshot = requests();
+            assertThat(snapshot).hasSize(1);
+            return snapshot.get(0);
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            synchronized (requests) {
+                requests.add(new RecordedRequest(exchange.getRequestURI().getPath(), requestBody));
+            }
+
+            String rawResponse = responses.poll();
+            if (rawResponse == null) {
+                write(exchange, 500, "{\"errors\":[{\"message\":\"missing mock response\"}]}");
+                return;
+            }
+
+            int delimiter = rawResponse.indexOf('\n');
+            int status = Integer.parseInt(rawResponse.substring(0, delimiter));
+            String body = rawResponse.substring(delimiter + 1);
+            write(exchange, status, body);
+        }
+
+        private void write(
+                HttpExchange exchange,
+                int status,
+                String body
+        ) throws IOException {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(bytes);
+            }
+        }
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepositoryQueryTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepositoryQueryTest.java
@@ -23,4 +23,20 @@ class PushMessageRepositoryQueryTest {
         assertThat(query).contains("receipt_available_at <= :now");
         assertThat(query).contains("FOR UPDATE SKIP LOCKED");
     }
+
+    @Test
+    void staleSendingQueryTargetsOnlyOldSendingMessages() throws Exception {
+        Method method = PushMessageRepository.class.getMethod(
+                "findStaleSendingForUpdateSkipLocked",
+                java.time.LocalDateTime.class,
+                int.class
+        );
+
+        String query = method.getAnnotation(Query.class).value();
+
+        assertThat(query).contains("status = 'SENDING'");
+        assertThat(query).contains("updated_at <= :staleBefore");
+        assertThat(query).contains("LIMIT :limit");
+        assertThat(query).contains("FOR UPDATE SKIP LOCKED");
+    }
 }

--- a/src/test/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepositoryQueryTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/repository/PushMessageRepositoryQueryTest.java
@@ -1,0 +1,26 @@
+package devkor.com.teamcback.domain.notification.repository;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushMessageRepositoryQueryTest {
+
+    @Test
+    void dueReceiptQueryTargetsOnlyReceiptPendingMessagesWithAvailableReceipts() throws Exception {
+        Method method = PushMessageRepository.class.getMethod(
+                "findDueReceiptPendingForUpdateSkipLocked",
+                java.time.LocalDateTime.class,
+                int.class
+        );
+
+        String query = method.getAnnotation(Query.class).value();
+
+        assertThat(query).contains("status = 'RECEIPT_PENDING'");
+        assertThat(query).contains("expo_ticket_id IS NOT NULL");
+        assertThat(query).contains("receipt_available_at <= :now");
+        assertThat(query).contains("FOR UPDATE SKIP LOCKED");
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageRecoverySchedulerTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/scheduler/PushMessageRecoverySchedulerTest.java
@@ -1,0 +1,36 @@
+package devkor.com.teamcback.domain.notification.scheduler;
+
+import devkor.com.teamcback.domain.notification.service.PushMessageRecoveryWorker;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class PushMessageRecoverySchedulerTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withBean(PushMessageRecoveryWorker.class, () -> mock(PushMessageRecoveryWorker.class))
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void schedulerIsDisabledByDefault() {
+        contextRunner.run(context -> assertThat(context)
+                .doesNotHaveBean(PushMessageRecoveryScheduler.class));
+    }
+
+    @Test
+    void schedulerIsDisabledWhenPropertyIsFalse() {
+        contextRunner
+                .withPropertyValues("push.recovery-worker.enabled=false")
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(PushMessageRecoveryScheduler.class));
+    }
+
+    @Configuration
+    @Import(PushMessageRecoveryScheduler.class)
+    static class TestConfig {
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/service/NotificationTestServiceTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/service/NotificationTestServiceTest.java
@@ -1,0 +1,193 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.client.ExpoPushClient;
+import devkor.com.teamcback.domain.notification.dto.request.NotificationTestReq;
+import devkor.com.teamcback.domain.notification.dto.response.NotificationTestRes;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationTestServiceTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Mock
+    private PushInstallationRepository pushInstallationRepository;
+
+    @Mock
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Mock
+    private PushMessageRepository pushMessageRepository;
+
+    @Mock
+    private PushPayloadFactory pushPayloadFactory;
+
+    @Test
+    void sendTestEnqueuesQueuedMessageWithoutExpoClientDependency() {
+        PushInstallation installation = installation();
+        when(pushInstallationRepository.findByInstallationId("install-1"))
+                .thenReturn(Optional.of(installation));
+        when(pushDispatchRepository.findByIdempotencyKey("7b347ad7-6138-4cb7-af7d-f5201703a596"))
+                .thenReturn(Optional.empty());
+        when(pushPayloadFactory.serializeActionParams(any()))
+                .thenReturn("{}");
+        when(pushDispatchRepository.saveAndFlush(any(PushDispatch.class)))
+                .thenAnswer(invocation -> {
+                    PushDispatch dispatch = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+                    return dispatch;
+                });
+        when(pushMessageRepository.saveAndFlush(any(PushMessage.class)))
+                .thenAnswer(invocation -> {
+                    PushMessage message = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(message, "pushMessageId", 20L);
+                    return message;
+                });
+
+        NotificationTestService service = service();
+        NotificationTestRes response = service.sendTest(
+                1L,
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                new NotificationTestReq(1, "install-1")
+        );
+
+        assertThat(response.notificationId()).isEqualTo("20");
+        assertThat(response.messageStatus()).isEqualTo(PushMessageStatus.QUEUED);
+        assertThat(response.ticketId()).isNull();
+        assertThat(hasExpoPushClientField()).isFalse();
+    }
+
+    @Test
+    void sendTestReturnsExistingDispatchMessageForSameIdempotencyKey() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = message(dispatch, installation);
+        ReflectionTestUtils.setField(message, "pushMessageId", 20L);
+
+        when(pushInstallationRepository.findByInstallationId("install-1"))
+                .thenReturn(Optional.of(installation));
+        when(pushDispatchRepository.findByIdempotencyKey("7b347ad7-6138-4cb7-af7d-f5201703a596"))
+                .thenReturn(Optional.of(dispatch));
+        when(pushMessageRepository.findAllByDispatch(dispatch))
+                .thenReturn(List.of(message));
+
+        NotificationTestRes response = service().sendTest(
+                1L,
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                new NotificationTestReq(1, "install-1")
+        );
+
+        assertThat(response.notificationId()).isEqualTo("20");
+        assertThat(response.messageStatus()).isEqualTo(PushMessageStatus.QUEUED);
+        verify(pushDispatchRepository, never()).saveAndFlush(any(PushDispatch.class));
+        verify(pushMessageRepository, never()).saveAndFlush(any(PushMessage.class));
+    }
+
+    @Test
+    void receiptPendingDoesNotCompleteDispatch() {
+        PushDispatch dispatch = dispatch();
+        dispatch.updateRecipientCount(1);
+
+        dispatch.updateStatusFromMessageSummary(
+                1,
+                0,
+                0,
+                0,
+                java.time.LocalDateTime.now(CLOCK)
+        );
+
+        assertThat(dispatch.getStatus()).isEqualTo(PushDispatchStatus.PROCESSING);
+        assertThat(dispatch.getCompletedAt()).isNull();
+    }
+
+    private NotificationTestService service() {
+        return new NotificationTestService(
+                pushInstallationRepository,
+                pushDispatchRepository,
+                pushMessageRepository,
+                pushPayloadFactory,
+                CLOCK
+        );
+    }
+
+    private PushInstallation installation() {
+        PushInstallation installation = new PushInstallation(
+                1L,
+                "install-1",
+                "ExponentPushToken[token]",
+                AppVariant.DEV
+        );
+        ReflectionTestUtils.setField(installation, "pushInstallationId", 100L);
+        return installation;
+    }
+
+    private PushDispatch dispatch() {
+        PushDispatch dispatch = new PushDispatch(
+                NotificationType.GENERAL,
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                "{}",
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                1L,
+                java.time.LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        return dispatch;
+    }
+
+    private PushMessage message(
+            PushDispatch dispatch,
+            PushInstallation installation
+    ) {
+        return new PushMessage(
+                dispatch,
+                installation,
+                java.time.LocalDateTime.now(CLOCK)
+        );
+    }
+
+    private boolean hasExpoPushClientField() {
+        return Arrays.stream(NotificationTestService.class.getDeclaredFields())
+                .map(Field::getType)
+                .anyMatch(ExpoPushClient.class::equals);
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimServiceTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/service/PushMessageClaimServiceTest.java
@@ -1,0 +1,200 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushWorkerProperties;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushErrorDetails;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushTicket;
+import devkor.com.teamcback.domain.notification.dto.worker.PushSendItem;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PushMessageClaimServiceTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Mock
+    private PushMessageRepository pushMessageRepository;
+
+    @Mock
+    private PushInstallationRepository pushInstallationRepository;
+
+    @Mock
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Mock
+    private PushPayloadFactory pushPayloadFactory;
+
+    @Test
+    void ticketOkStoresReceiptAvailableAtFifteenMinutesLater() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = message(dispatch, installation);
+
+        stubRecordTickets(message, dispatch, PushMessageStatus.RECEIPT_PENDING);
+
+        service().recordTickets(
+                List.of(new PushSendItem(20L, 10L, null)),
+                List.of(new ExpoPushTicket("ok", "ticket-1", null, null))
+        );
+
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.RECEIPT_PENDING);
+        assertThat(message.getExpoTicketId()).isEqualTo("ticket-1");
+        assertThat(message.getReceiptAvailableAt())
+                .isEqualTo(LocalDateTime.now(CLOCK).plusMinutes(15));
+    }
+
+    @Test
+    void deviceNotRegisteredTicketFailsMessageAndDeactivatesInstallation() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = message(dispatch, installation);
+
+        stubRecordTickets(message, dispatch, PushMessageStatus.FAILED);
+        when(pushInstallationRepository.findById(100L))
+                .thenReturn(Optional.of(installation));
+
+        service().recordTickets(
+                List.of(new PushSendItem(20L, 10L, null)),
+                List.of(new ExpoPushTicket(
+                        "error",
+                        null,
+                        null,
+                        new ExpoPushErrorDetails("DeviceNotRegistered")
+                ))
+        );
+
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(message.getReceiptAvailableAt()).isNull();
+        assertThat(installation.isActive()).isFalse();
+    }
+
+    private void stubRecordTickets(
+            PushMessage message,
+            PushDispatch dispatch,
+            PushMessageStatus status
+    ) {
+        when(pushMessageRepository.findAllByPushMessageIdIn(any(Collection.class)))
+                .thenReturn(List.of(message));
+        when(pushMessageRepository.countStatusesByDispatchIds(any(Collection.class)))
+                .thenReturn(List.of(new StatusCount(10L, status, 1L)));
+        when(pushDispatchRepository.findAllById(any(Iterable.class)))
+                .thenReturn(List.of(dispatch));
+    }
+
+    private PushMessageClaimService service() {
+        return new PushMessageClaimService(
+                pushMessageRepository,
+                pushInstallationRepository,
+                pushDispatchRepository,
+                pushPayloadFactory,
+                new PushWorkerProperties(true, 100, 3, 30_000L),
+                CLOCK
+        );
+    }
+
+    private PushInstallation installation() {
+        PushInstallation installation = new PushInstallation(
+                1L,
+                "install-1",
+                "ExponentPushToken[token]",
+                AppVariant.DEV
+        );
+        ReflectionTestUtils.setField(installation, "pushInstallationId", 100L);
+        return installation;
+    }
+
+    private PushDispatch dispatch() {
+        PushDispatch dispatch = new PushDispatch(
+                NotificationType.GENERAL,
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                "{}",
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                1L,
+                LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        dispatch.updateRecipientCount(1);
+        return dispatch;
+    }
+
+    private PushMessage message(
+            PushDispatch dispatch,
+            PushInstallation installation
+    ) {
+        PushMessage message = new PushMessage(
+                dispatch,
+                installation,
+                LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(message, "pushMessageId", 20L);
+        return message;
+    }
+
+    private static class StatusCount implements PushMessageRepository.PushDispatchMessageStatusCount {
+
+        private final Long dispatchId;
+        private final PushMessageStatus status;
+        private final long count;
+
+        private StatusCount(
+                Long dispatchId,
+                PushMessageStatus status,
+                long count
+        ) {
+            this.dispatchId = dispatchId;
+            this.status = status;
+            this.count = count;
+        }
+
+        @Override
+        public Long getDispatchId() {
+            return dispatchId;
+        }
+
+        @Override
+        public PushMessageStatus getStatus() {
+            return status;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryServiceTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/service/PushMessageRecoveryServiceTest.java
@@ -1,0 +1,229 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushRecoveryWorkerProperties;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PushMessageRecoveryServiceTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Mock
+    private PushMessageRepository pushMessageRepository;
+
+    @Mock
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Test
+    void staleSendingWithoutTicketFailsWithWorkerInterrupted() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = message(dispatch, installation);
+        message.markSending(LocalDateTime.now(CLOCK).minusMinutes(31));
+
+        stubStaleMessages(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.FAILED, 1L)));
+
+        int recoveredCount = service(30, 100).recoverStaleSendingMessages();
+
+        assertThat(recoveredCount).isEqualTo(1);
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(message.getTicketStatus()).isEqualTo("worker_interrupted");
+        assertThat(message.getTicketError()).isEqualTo("worker_interrupted");
+        assertThat(message.getReceiptAvailableAt()).isNull();
+        assertThat(dispatch.getStatus()).isEqualTo(PushDispatchStatus.FAILED);
+    }
+
+    @Test
+    void staleSendingWithTicketRecoversToReceiptPendingWithoutResend() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = message(dispatch, installation);
+        message.recordTicket("ok", "ticket-1", null, LocalDateTime.now(CLOCK).minusMinutes(40));
+        message.markReceiptChecking(LocalDateTime.now(CLOCK).minusMinutes(31));
+        ReflectionTestUtils.setField(message, "receiptAvailableAt", null);
+
+        stubStaleMessages(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.RECEIPT_PENDING, 1L)));
+
+        int recoveredCount = service(30, 100).recoverStaleSendingMessages();
+
+        assertThat(recoveredCount).isEqualTo(1);
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.RECEIPT_PENDING);
+        assertThat(message.getExpoTicketId()).isEqualTo("ticket-1");
+        assertThat(message.getReceiptAvailableAt()).isEqualTo(LocalDateTime.now(CLOCK));
+        assertThat(dispatch.getStatus()).isEqualTo(PushDispatchStatus.PROCESSING);
+    }
+
+    @Test
+    void nonStaleSendingIsNotChangedWhenQueryDoesNotReturnIt() {
+        PushMessage message = message(dispatch(), installation());
+        message.markSending(LocalDateTime.now(CLOCK).minusMinutes(29));
+        when(pushMessageRepository.findStaleSendingForUpdateSkipLocked(any(LocalDateTime.class), eq(100)))
+                .thenReturn(List.of());
+
+        int recoveredCount = service(30, 100).recoverStaleSendingMessages();
+
+        assertThat(recoveredCount).isZero();
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.SENDING);
+    }
+
+    @Test
+    void nonSendingMessageIsNotChangedWhenQueryDoesNotReturnIt() {
+        PushMessage message = message(dispatch(), installation());
+        when(pushMessageRepository.findStaleSendingForUpdateSkipLocked(any(LocalDateTime.class), eq(100)))
+                .thenReturn(List.of());
+
+        int recoveredCount = service(30, 100).recoverStaleSendingMessages();
+
+        assertThat(recoveredCount).isZero();
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.QUEUED);
+    }
+
+    @Test
+    void recoveryUsesConfiguredStaleThresholdAndBatchSize() {
+        when(pushMessageRepository.findStaleSendingForUpdateSkipLocked(any(LocalDateTime.class), eq(7)))
+                .thenReturn(List.of());
+
+        service(45, 7).recoverStaleSendingMessages();
+
+        ArgumentCaptor<LocalDateTime> staleBeforeCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(pushMessageRepository).findStaleSendingForUpdateSkipLocked(staleBeforeCaptor.capture(), eq(7));
+        assertThat(staleBeforeCaptor.getValue()).isEqualTo(LocalDateTime.now(CLOCK).minusMinutes(45));
+    }
+
+    private PushMessageRecoveryService service(
+            long staleThresholdMinutes,
+            int batchSize
+    ) {
+        return new PushMessageRecoveryService(
+                pushMessageRepository,
+                pushDispatchRepository,
+                new PushRecoveryWorkerProperties(true, "0 0 4 * * *", staleThresholdMinutes, batchSize),
+                CLOCK
+        );
+    }
+
+    private void stubStaleMessages(List<PushMessage> messages) {
+        when(pushMessageRepository.findStaleSendingForUpdateSkipLocked(any(LocalDateTime.class), eq(100)))
+                .thenReturn(messages);
+    }
+
+    private void stubStatusCounts(
+            PushDispatch dispatch,
+            List<PushMessageRepository.PushDispatchMessageStatusCount> counts
+    ) {
+        when(pushMessageRepository.countStatusesByDispatchIds(any(Collection.class)))
+                .thenReturn(counts);
+        when(pushDispatchRepository.findAllById(any(Iterable.class)))
+                .thenReturn(List.of(dispatch));
+    }
+
+    private PushInstallation installation() {
+        PushInstallation installation = new PushInstallation(
+                1L,
+                "install-1",
+                "ExponentPushToken[token]",
+                AppVariant.DEV
+        );
+        ReflectionTestUtils.setField(installation, "pushInstallationId", 100L);
+        return installation;
+    }
+
+    private PushDispatch dispatch() {
+        PushDispatch dispatch = new PushDispatch(
+                NotificationType.GENERAL,
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                "{}",
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                1L,
+                LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        dispatch.updateRecipientCount(1);
+        return dispatch;
+    }
+
+    private PushMessage message(
+            PushDispatch dispatch,
+            PushInstallation installation
+    ) {
+        PushMessage message = new PushMessage(
+                dispatch,
+                installation,
+                LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(message, "pushMessageId", 20L);
+        return message;
+    }
+
+    private static class StatusCount implements PushMessageRepository.PushDispatchMessageStatusCount {
+
+        private final Long dispatchId;
+        private final PushMessageStatus status;
+        private final long count;
+
+        private StatusCount(
+                Long dispatchId,
+                PushMessageStatus status,
+                long count
+        ) {
+            this.dispatchId = dispatchId;
+            this.status = status;
+            this.count = count;
+        }
+
+        @Override
+        public Long getDispatchId() {
+            return dispatchId;
+        }
+
+        @Override
+        public PushMessageStatus getStatus() {
+            return status;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/service/PushReceiptClaimServiceTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/service/PushReceiptClaimServiceTest.java
@@ -1,0 +1,305 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.config.PushReceiptWorkerProperties;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushErrorDetails;
+import devkor.com.teamcback.domain.notification.dto.expo.ExpoPushReceipt;
+import devkor.com.teamcback.domain.notification.dto.worker.PushReceiptItem;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.PushMessage;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PushReceiptClaimServiceTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Mock
+    private PushMessageRepository pushMessageRepository;
+
+    @Mock
+    private PushInstallationRepository pushInstallationRepository;
+
+    @Mock
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Test
+    void claimDueReceiptsMarksDueReceiptPendingMessagesAsSending() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = receiptPendingMessage(dispatch, installation, "ticket-1");
+
+        when(pushMessageRepository.findDueReceiptPendingForUpdateSkipLocked(any(LocalDateTime.class), anyInt()))
+                .thenReturn(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.SENDING, 1L)));
+
+        List<PushReceiptItem> items = service().claimDueReceipts();
+
+        assertThat(items).containsExactly(new PushReceiptItem(20L, 10L, "ticket-1"));
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.SENDING);
+    }
+
+    @Test
+    void receiptOkMarksDeliveredByTicketIdMap() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage first = receiptPendingMessage(dispatch, installation, "ticket-1");
+        PushMessage second = receiptPendingMessage(dispatch, installation, "ticket-2");
+        ReflectionTestUtils.setField(second, "pushMessageId", 21L);
+
+        stubMessages(List.of(first, second));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.DELIVERED, 2L)));
+
+        service().recordReceipts(
+                List.of(
+                        new PushReceiptItem(20L, 10L, "ticket-1"),
+                        new PushReceiptItem(21L, 10L, "ticket-2")
+                ),
+                Map.of(
+                        "ticket-2", new ExpoPushReceipt("ok", null, null),
+                        "ticket-1", new ExpoPushReceipt("error", "failed", new ExpoPushErrorDetails("MessageTooBig"))
+                )
+        );
+
+        assertThat(first.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(first.getReceiptError()).isEqualTo("MessageTooBig");
+        assertThat(second.getStatus()).isEqualTo(PushMessageStatus.DELIVERED);
+        assertThat(second.getReceiptError()).isNull();
+    }
+
+    @Test
+    void deviceNotRegisteredReceiptFailsMessageAndDeactivatesInstallation() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = receiptPendingMessage(dispatch, installation, "ticket-1");
+
+        stubMessages(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.FAILED, 1L)));
+        when(pushInstallationRepository.findById(100L))
+                .thenReturn(Optional.of(installation));
+
+        service().recordReceipts(
+                List.of(new PushReceiptItem(20L, 10L, "ticket-1")),
+                Map.of("ticket-1", new ExpoPushReceipt(
+                        "error",
+                        null,
+                        new ExpoPushErrorDetails("DeviceNotRegistered")
+                ))
+        );
+
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(installation.isActive()).isFalse();
+    }
+
+    @Test
+    void missingReceiptSchedulesLimitedRetry() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = receiptPendingMessage(dispatch, installation, "ticket-1");
+
+        stubMessages(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.RECEIPT_PENDING, 1L)));
+
+        service().recordReceipts(
+                List.of(new PushReceiptItem(20L, 10L, "ticket-1")),
+                Map.of()
+        );
+
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.RECEIPT_PENDING);
+        assertThat(message.getReceiptAttempts()).isEqualTo(1);
+        assertThat(message.getReceiptAvailableAt()).isEqualTo(LocalDateTime.now(CLOCK).plusMinutes(1));
+    }
+
+    @Test
+    void maxReceiptAttemptsMarksFailed() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = receiptPendingMessage(dispatch, installation, "ticket-1");
+        ReflectionTestUtils.setField(message, "receiptAttempts", 2);
+
+        stubMessages(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.FAILED, 1L)));
+
+        service().recordReceipts(
+                List.of(new PushReceiptItem(20L, 10L, "ticket-1")),
+                Map.of()
+        );
+
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(message.getReceiptAvailableAt()).isNull();
+    }
+
+    @Test
+    void sentMoreThanTwentyFourHoursAgoExpiresWithoutReceiptRequestItem() {
+        PushInstallation installation = installation();
+        PushDispatch dispatch = dispatch();
+        PushMessage message = receiptPendingMessage(dispatch, installation, "ticket-1");
+        ReflectionTestUtils.setField(message, "sentAt", LocalDateTime.now(CLOCK).minusHours(25));
+
+        when(pushMessageRepository.findDueReceiptPendingForUpdateSkipLocked(any(LocalDateTime.class), anyInt()))
+                .thenReturn(List.of(message));
+        stubStatusCounts(dispatch, List.of(new StatusCount(10L, PushMessageStatus.FAILED, 1L)));
+
+        List<PushReceiptItem> items = service().claimDueReceipts();
+
+        assertThat(items).isEmpty();
+        assertThat(message.getStatus()).isEqualTo(PushMessageStatus.FAILED);
+        assertThat(message.getReceiptError()).isEqualTo("receipt_expired");
+    }
+
+    @Test
+    void dispatchSummaryUsesOnlyFinalStatusesForCompletion() {
+        PushDispatch allDelivered = dispatch();
+        allDelivered.updateRecipientCount(2);
+        allDelivered.updateStatusFromMessageSummary(0, 0, 2, 0, LocalDateTime.now(CLOCK));
+        assertThat(allDelivered.getStatus()).isEqualTo(PushDispatchStatus.COMPLETED);
+
+        PushDispatch partial = dispatch();
+        partial.updateRecipientCount(2);
+        partial.updateStatusFromMessageSummary(0, 0, 1, 1, LocalDateTime.now(CLOCK));
+        assertThat(partial.getStatus()).isEqualTo(PushDispatchStatus.PARTIAL_FAILED);
+
+        PushDispatch failed = dispatch();
+        failed.updateRecipientCount(2);
+        failed.updateStatusFromMessageSummary(0, 0, 0, 2, LocalDateTime.now(CLOCK));
+        assertThat(failed.getStatus()).isEqualTo(PushDispatchStatus.FAILED);
+
+        PushDispatch processing = dispatch();
+        processing.updateRecipientCount(2);
+        processing.updateStatusFromMessageSummary(1, 0, 1, 0, LocalDateTime.now(CLOCK));
+        assertThat(processing.getStatus()).isEqualTo(PushDispatchStatus.PROCESSING);
+    }
+
+    private PushReceiptClaimService service() {
+        return new PushReceiptClaimService(
+                pushMessageRepository,
+                pushInstallationRepository,
+                pushDispatchRepository,
+                new PushReceiptWorkerProperties(true, 1000, 3),
+                CLOCK
+        );
+    }
+
+    private void stubMessages(List<PushMessage> messages) {
+        when(pushMessageRepository.findAllByPushMessageIdIn(any(Collection.class)))
+                .thenReturn(messages);
+    }
+
+    private void stubStatusCounts(
+            PushDispatch dispatch,
+            List<PushMessageRepository.PushDispatchMessageStatusCount> counts
+    ) {
+        when(pushMessageRepository.countStatusesByDispatchIds(any(Collection.class)))
+                .thenReturn(counts);
+        when(pushDispatchRepository.findAllById(any(Iterable.class)))
+                .thenReturn(List.of(dispatch));
+    }
+
+    private PushInstallation installation() {
+        PushInstallation installation = new PushInstallation(
+                1L,
+                "install-1",
+                "ExponentPushToken[token]",
+                AppVariant.DEV
+        );
+        ReflectionTestUtils.setField(installation, "pushInstallationId", 100L);
+        return installation;
+    }
+
+    private PushDispatch dispatch() {
+        PushDispatch dispatch = new PushDispatch(
+                NotificationType.GENERAL,
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                "{}",
+                "7b347ad7-6138-4cb7-af7d-f5201703a596",
+                1L,
+                LocalDateTime.now(CLOCK)
+        );
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        dispatch.updateRecipientCount(1);
+        return dispatch;
+    }
+
+    private PushMessage receiptPendingMessage(
+            PushDispatch dispatch,
+            PushInstallation installation,
+            String ticketId
+    ) {
+        PushMessage message = new PushMessage(
+                dispatch,
+                installation,
+                LocalDateTime.now(CLOCK).minusMinutes(20)
+        );
+        ReflectionTestUtils.setField(message, "pushMessageId", 20L);
+        message.recordTicket("ok", ticketId, null, LocalDateTime.now(CLOCK).minusMinutes(20));
+        return message;
+    }
+
+    private static class StatusCount implements PushMessageRepository.PushDispatchMessageStatusCount {
+
+        private final Long dispatchId;
+        private final PushMessageStatus status;
+        private final long count;
+
+        private StatusCount(
+                Long dispatchId,
+                PushMessageStatus status,
+                long count
+        ) {
+            this.dispatchId = dispatchId;
+            this.status = status;
+            this.count = count;
+        }
+
+        @Override
+        public Long getDispatchId() {
+            return dispatchId;
+        }
+
+        @Override
+        public PushMessageStatus getStatus() {
+            return status;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 개요
DB에 저장된 푸시 메시지를 Expo Push API로 발송하고, ticket과 receipt 결과를 처리하는 worker를 구현했습니다.

## 작업사항
- QUEUED 상태의 푸시 메시지를 조회하고 점유하는 send worker 추가
- Expo Push API 최대 100건 단위 발송 및 ticket 결과 저장
- 일시적 오류 발생 시 제한된 횟수만 재시도하도록 처리
- RECEIPT_PENDING 메시지의 최종 전달 결과를 조회하는 receipt worker 추가
- receipt 결과에 따라 DELIVERED 또는 FAILED 상태로 변경
- DeviceNotRegistered 발생 시 해당 installation 비활성화
- PushMessage 결과에 따른 PushDispatch 최종 상태 집계
- 푸시 생성부터 ticket·receipt 처리까지의 통합 테스트 추가

## 관련 이슈
- 관련 이슈 없음