### PR TITLE
Feat/push admin api

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/notification/controller/AdminNotificationController.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/controller/AdminNotificationController.java
@@ -13,6 +13,8 @@ import devkor.com.teamcback.global.exception.exception.GlobalException;
 import devkor.com.teamcback.global.response.CommonResponse;
 import devkor.com.teamcback.global.security.UserDetailsImpl;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,6 +39,14 @@ public class AdminNotificationController {
 
     private final AdminNotificationService adminNotificationService;
 
+    @Operation(
+            summary = "푸시 대상 installation 검색",
+            description = """
+                userId 또는 installationId를 기준으로
+                푸시 발송 대상 기기를 조회합니다.
+                ExpoPushToken 원문은 응답하지 않습니다.
+                """
+    )
     @GetMapping("/installations/search")
     public CommonResponse<List<AdminPushInstallationRes>> searchInstallations(
             @RequestParam(required = false) Long userId,
@@ -45,6 +55,14 @@ public class AdminNotificationController {
         return CommonResponse.success(adminNotificationService.searchInstallations(userId, installationId));
     }
 
+    @Operation(
+            summary = "관리자 푸시 발송 미리보기",
+            description = """
+                푸시를 실제로 생성하지 않고
+                대상 기기 수와 최종 payload를 확인합니다.
+                PushDispatch와 PushMessage는 저장하지 않습니다.
+                """
+    )
     @PostMapping("/dispatches/preview")
     public CommonResponse<AdminPushDispatchPreviewRes> preview(
             @RequestBody AdminPushDispatchReq request
@@ -52,6 +70,15 @@ public class AdminNotificationController {
         return CommonResponse.success(adminNotificationService.preview(request));
     }
 
+
+    @Operation(
+            summary = "관리자 푸시 수동 발송",
+            description = """
+                관리자가 입력한 내용으로
+                PushDispatch와 PushMessage를 생성합니다.
+                실제 Expo 전송은 기존 비동기 worker가 처리합니다.
+                """
+    )
     @PostMapping("/dispatches")
     public CommonResponse<PushDispatchEnqueueRes> enqueue(
             @AuthenticationPrincipal UserDetailsImpl userDetail,
@@ -69,6 +96,14 @@ public class AdminNotificationController {
         ));
     }
 
+    @Operation(
+            summary = "관리자 푸시 발송 이력 조회",
+            description = """
+                관리자 푸시 발송 내역을 최신순으로 조회합니다.
+                appVariant와 발송 상태로 필터링할 수 있습니다.
+                """
+    )
+
     @GetMapping("/dispatches")
     public CommonResponse<Page<AdminPushDispatchSummaryRes>> getDispatches(
             @RequestParam(defaultValue = DEFAULT_PAGE) int page,
@@ -84,6 +119,14 @@ public class AdminNotificationController {
         ));
     }
 
+    @Operation(
+            summary = "관리자 푸시 발송 상세 조회",
+            description = """
+                발송 기본 정보와 전체 대상 수,
+                메시지 상태별 처리 건수를 조회합니다.
+                ExpoPushToken과 개별 메시지 전체 목록은 반환하지 않습니다.
+                """
+    )
     @GetMapping("/dispatches/{dispatchId}")
     public CommonResponse<AdminPushDispatchDetailRes> getDispatch(
             @PathVariable Long dispatchId

--- a/src/main/java/devkor/com/teamcback/domain/notification/controller/AdminNotificationController.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/controller/AdminNotificationController.java
@@ -1,0 +1,93 @@
+package devkor.com.teamcback.domain.notification.controller;
+
+import devkor.com.teamcback.domain.notification.dto.request.AdminPushDispatchReq;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchDetailRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchPreviewRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchSummaryRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushInstallationRes;
+import devkor.com.teamcback.domain.notification.dto.response.PushDispatchEnqueueRes;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.service.AdminNotificationService;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import devkor.com.teamcback.global.response.CommonResponse;
+import devkor.com.teamcback.global.security.UserDetailsImpl;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static devkor.com.teamcback.global.response.ResultCode.UNAUTHORIZED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/notifications")
+public class AdminNotificationController {
+
+    private static final String DEFAULT_PAGE = "1";
+    private static final String DEFAULT_SIZE = "20";
+
+    private final AdminNotificationService adminNotificationService;
+
+    @GetMapping("/installations/search")
+    public CommonResponse<List<AdminPushInstallationRes>> searchInstallations(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) String installationId
+    ) {
+        return CommonResponse.success(adminNotificationService.searchInstallations(userId, installationId));
+    }
+
+    @PostMapping("/dispatches/preview")
+    public CommonResponse<AdminPushDispatchPreviewRes> preview(
+            @RequestBody AdminPushDispatchReq request
+    ) {
+        return CommonResponse.success(adminNotificationService.preview(request));
+    }
+
+    @PostMapping("/dispatches")
+    public CommonResponse<PushDispatchEnqueueRes> enqueue(
+            @AuthenticationPrincipal UserDetailsImpl userDetail,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            @RequestBody AdminPushDispatchReq request
+    ) {
+        if (userDetail == null) {
+            throw new GlobalException(UNAUTHORIZED);
+        }
+
+        return CommonResponse.success(adminNotificationService.enqueue(
+                userDetail.getUser().getUserId(),
+                idempotencyKey,
+                request
+        ));
+    }
+
+    @GetMapping("/dispatches")
+    public CommonResponse<Page<AdminPushDispatchSummaryRes>> getDispatches(
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+            @RequestParam(required = false) AppVariant appVariant,
+            @RequestParam(required = false) PushDispatchStatus status
+    ) {
+        return CommonResponse.success(adminNotificationService.getDispatches(
+                page,
+                size,
+                appVariant,
+                status
+        ));
+    }
+
+    @GetMapping("/dispatches/{dispatchId}")
+    public CommonResponse<AdminPushDispatchDetailRes> getDispatch(
+            @PathVariable Long dispatchId
+    ) {
+        return CommonResponse.success(adminNotificationService.getDispatch(dispatchId));
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/request/AdminPushDispatchReq.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/request/AdminPushDispatchReq.java
@@ -1,0 +1,20 @@
+package devkor.com.teamcback.domain.notification.dto.request;
+
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import java.util.Map;
+
+public record AdminPushDispatchReq(
+        PushMode mode,
+        AppVariant appVariant,
+        PushTargetType targetType,
+        String targetValue,
+        String title,
+        String body,
+        PushActionType actionType,
+        Map<String, Object> actionParams,
+        Boolean confirm
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchDetailRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchDetailRes.java
@@ -1,0 +1,58 @@
+package devkor.com.teamcback.domain.notification.dto.response;
+
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record AdminPushDispatchDetailRes(
+        Long dispatchId,
+        NotificationType notificationType,
+        PushMode mode,
+        AppVariant appVariant,
+        PushTargetType targetType,
+        String targetValue,
+        String title,
+        String body,
+        PushActionType actionType,
+        String actionParams,
+        int recipientCount,
+        PushDispatchStatus status,
+        Map<PushMessageStatus, Long> messageStatusCounts,
+        String idempotencyKey,
+        Long createdBy,
+        LocalDateTime createdAt,
+        LocalDateTime completedAt
+) {
+
+    public AdminPushDispatchDetailRes(
+            PushDispatch dispatch,
+            Map<PushMessageStatus, Long> messageStatusCounts
+    ) {
+        this(
+                dispatch.getPushDispatchId(),
+                dispatch.getNotificationType(),
+                dispatch.getMode(),
+                dispatch.getAppVariant(),
+                dispatch.getTargetType(),
+                dispatch.getTargetValue(),
+                dispatch.getTitle(),
+                dispatch.getBody(),
+                dispatch.getActionType(),
+                dispatch.getActionParams(),
+                dispatch.getRecipientCount(),
+                dispatch.getStatus(),
+                messageStatusCounts,
+                dispatch.getIdempotencyKey(),
+                dispatch.getCreatedBy(),
+                dispatch.getCreatedAt(),
+                dispatch.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchPreviewRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchPreviewRes.java
@@ -1,0 +1,9 @@
+package devkor.com.teamcback.domain.notification.dto.response;
+
+import devkor.com.teamcback.domain.notification.dto.payload.PushPayload;
+
+public record AdminPushDispatchPreviewRes(
+        int recipientCount,
+        PushPayload payload
+) {
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchSummaryRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushDispatchSummaryRes.java
@@ -1,0 +1,47 @@
+package devkor.com.teamcback.domain.notification.dto.response;
+
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import java.time.LocalDateTime;
+
+public record AdminPushDispatchSummaryRes(
+        Long dispatchId,
+        NotificationType notificationType,
+        PushMode mode,
+        AppVariant appVariant,
+        PushTargetType targetType,
+        String targetValue,
+        String title,
+        String body,
+        PushActionType actionType,
+        int recipientCount,
+        PushDispatchStatus status,
+        Long createdBy,
+        LocalDateTime createdAt,
+        LocalDateTime completedAt
+) {
+
+    public AdminPushDispatchSummaryRes(PushDispatch dispatch) {
+        this(
+                dispatch.getPushDispatchId(),
+                dispatch.getNotificationType(),
+                dispatch.getMode(),
+                dispatch.getAppVariant(),
+                dispatch.getTargetType(),
+                dispatch.getTargetValue(),
+                dispatch.getTitle(),
+                dispatch.getBody(),
+                dispatch.getActionType(),
+                dispatch.getRecipientCount(),
+                dispatch.getStatus(),
+                dispatch.getCreatedBy(),
+                dispatch.getCreatedAt(),
+                dispatch.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushInstallationRes.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/dto/response/AdminPushInstallationRes.java
@@ -1,0 +1,32 @@
+package devkor.com.teamcback.domain.notification.dto.response;
+
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import java.time.LocalDateTime;
+
+public record AdminPushInstallationRes(
+        Long userId,
+        String installationId,
+        AppVariant appVariant,
+        boolean active,
+        LocalDateTime lastActiveAt,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        LocalDateTime deactivatedAt
+) {
+
+    public AdminPushInstallationRes(PushInstallation installation) {
+        this(
+                installation.getUserId(),
+                installation.getInstallationId(),
+                installation.getAppVariant(),
+                installation.isActive(),
+                installation.isActive()
+                        ? installation.getModifiedAt()
+                        : installation.getDeactivatedAt(),
+                installation.getCreatedAt(),
+                installation.getModifiedAt(),
+                installation.getDeactivatedAt()
+        );
+    }
+}

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushDispatchRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushDispatchRepository.java
@@ -1,12 +1,31 @@
 package devkor.com.teamcback.domain.notification.repository;
 
 import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PushDispatchRepository extends JpaRepository<PushDispatch, Long> {
 
     Optional<PushDispatch> findByIdempotencyKey(
             String idempotencyKey
+    );
+
+    @Query("""
+            SELECT d
+            FROM PushDispatch d
+            WHERE (:appVariant IS NULL OR d.appVariant = :appVariant)
+              AND (:status IS NULL OR d.status = :status)
+            ORDER BY d.createdAt DESC, d.pushDispatchId DESC
+            """)
+    Page<PushDispatch> findAdminDispatches(
+            @Param("appVariant") AppVariant appVariant,
+            @Param("status") PushDispatchStatus status,
+            Pageable pageable
     );
 }

--- a/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/repository/PushInstallationRepository.java
@@ -26,6 +26,10 @@ public interface PushInstallationRepository extends JpaRepository<PushInstallati
             Long userId
     );
 
+    List<PushInstallation> findAllByUserIdOrderByModifiedAtDescPushInstallationIdDesc(
+            Long userId
+    );
+
     Optional<PushInstallation> findByInstallationIdAndAppVariantAndActiveTrue(
             String installationId,
             AppVariant appVariant

--- a/src/main/java/devkor/com/teamcback/domain/notification/service/AdminNotificationService.java
+++ b/src/main/java/devkor/com/teamcback/domain/notification/service/AdminNotificationService.java
@@ -1,0 +1,205 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import devkor.com.teamcback.domain.notification.dto.payload.PushPayload;
+import devkor.com.teamcback.domain.notification.dto.request.AdminPushDispatchReq;
+import devkor.com.teamcback.domain.notification.dto.request.PushDispatchCommand;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchDetailRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchPreviewRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchSummaryRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushInstallationRes;
+import devkor.com.teamcback.domain.notification.dto.response.PushDispatchEnqueueRes;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import devkor.com.teamcback.domain.notification.resolver.PushTargetResolver;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static devkor.com.teamcback.global.response.ResultCode.FORBIDDEN;
+import static devkor.com.teamcback.global.response.ResultCode.INVALID_INPUT;
+import static devkor.com.teamcback.global.response.ResultCode.UNSUPPORTED_REQUEST;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminNotificationService {
+
+    private final PushInstallationRepository pushInstallationRepository;
+    private final PushDispatchRepository pushDispatchRepository;
+    private final PushMessageRepository pushMessageRepository;
+    private final PushTargetResolver pushTargetResolver;
+    private final PushPayloadFactory pushPayloadFactory;
+    private final PushDispatchService pushDispatchService;
+
+    @Value("${push.admin.production-enabled:false}")
+    private boolean productionEnabled;
+
+    public List<AdminPushInstallationRes> searchInstallations(
+            Long userId,
+            String installationId
+    ) {
+        if ((userId == null && !hasText(installationId))
+                || (userId != null && hasText(installationId))) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        if (userId != null) {
+            return pushInstallationRepository.findAllByUserIdOrderByModifiedAtDescPushInstallationIdDesc(userId)
+                    .stream()
+                    .map(AdminPushInstallationRes::new)
+                    .toList();
+        }
+
+        return pushInstallationRepository.findByInstallationId(installationId)
+                .stream()
+                .map(AdminPushInstallationRes::new)
+                .toList();
+    }
+
+    public AdminPushDispatchPreviewRes preview(AdminPushDispatchReq request) {
+        validateTargetRules(request);
+
+        List<PushInstallation> installations = pushTargetResolver.resolve(
+                request.targetType(),
+                request.targetValue(),
+                request.appVariant()
+        );
+
+        PushPayload payload = pushPayloadFactory.createForPreDispatchValidation(
+                request.title(),
+                request.body(),
+                request.mode(),
+                request.appVariant(),
+                request.actionType(),
+                request.actionParams()
+        );
+
+        return new AdminPushDispatchPreviewRes(
+                installations.size(),
+                payload
+        );
+    }
+
+    @Transactional
+    public PushDispatchEnqueueRes enqueue(
+            Long adminUserId,
+            String idempotencyKey,
+            AdminPushDispatchReq request
+    ) {
+        validateTargetRules(request);
+        validateProductionGate(request);
+
+        return pushDispatchService.enqueue(new PushDispatchCommand(
+                NotificationType.GENERAL,
+                request.mode(),
+                request.appVariant(),
+                request.targetType(),
+                request.targetValue(),
+                request.title(),
+                request.body(),
+                request.actionType(),
+                request.actionParams(),
+                idempotencyKey,
+                adminUserId
+        ));
+    }
+
+    public Page<AdminPushDispatchSummaryRes> getDispatches(
+            int page,
+            int size,
+            AppVariant appVariant,
+            PushDispatchStatus status
+    ) {
+        if (page < 1 || size < 1) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return pushDispatchRepository.findAdminDispatches(appVariant, status, pageable)
+                .map(AdminPushDispatchSummaryRes::new);
+    }
+
+    public AdminPushDispatchDetailRes getDispatch(Long dispatchId) {
+        if (dispatchId == null) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        PushDispatch dispatch = pushDispatchRepository.findById(dispatchId)
+                .orElseThrow(() -> new GlobalException(INVALID_INPUT));
+
+        Map<PushMessageStatus, Long> statusCounts = zeroStatusCounts();
+        pushMessageRepository.countStatusesByDispatchIds(List.of(dispatchId))
+                .forEach(count -> statusCounts.put(count.getStatus(), count.getCount()));
+
+        return new AdminPushDispatchDetailRes(dispatch, statusCounts);
+    }
+
+    private void validateTargetRules(AdminPushDispatchReq request) {
+        if (request == null
+                || request.mode() == null
+                || request.appVariant() == null
+                || request.targetType() == null) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        if (PushTargetType.USER_GROUP.equals(request.targetType())) {
+            throw new GlobalException(UNSUPPORTED_REQUEST);
+        }
+
+        if (PushMode.TEST.equals(request.mode())
+                && !PushTargetType.INSTALLATION.equals(request.targetType())) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+
+        if (PushMode.ACTUAL.equals(request.mode())
+                && !PushTargetType.INSTALLATION.equals(request.targetType())
+                && !PushTargetType.USER.equals(request.targetType())) {
+            throw new GlobalException(UNSUPPORTED_REQUEST);
+        }
+    }
+
+    private void validateProductionGate(AdminPushDispatchReq request) {
+        if (!PushMode.ACTUAL.equals(request.mode())
+                || !AppVariant.PRODUCTION.equals(request.appVariant())) {
+            return;
+        }
+
+        if (!productionEnabled) {
+            throw new GlobalException(FORBIDDEN);
+        }
+
+        if (!Boolean.TRUE.equals(request.confirm())) {
+            throw new GlobalException(INVALID_INPUT);
+        }
+    }
+
+    private Map<PushMessageStatus, Long> zeroStatusCounts() {
+        Map<PushMessageStatus, Long> statusCounts = new EnumMap<>(PushMessageStatus.class);
+        for (PushMessageStatus status : PushMessageStatus.values()) {
+            statusCounts.put(status, 0L);
+        }
+        return statusCounts;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/test/java/devkor/com/teamcback/domain/notification/service/AdminNotificationServiceTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/notification/service/AdminNotificationServiceTest.java
@@ -1,0 +1,326 @@
+package devkor.com.teamcback.domain.notification.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.com.teamcback.domain.notification.dto.payload.PushPayload;
+import devkor.com.teamcback.domain.notification.dto.request.AdminPushDispatchReq;
+import devkor.com.teamcback.domain.notification.dto.request.PushDispatchCommand;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchDetailRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushDispatchPreviewRes;
+import devkor.com.teamcback.domain.notification.dto.response.AdminPushInstallationRes;
+import devkor.com.teamcback.domain.notification.dto.response.PushDispatchEnqueueRes;
+import devkor.com.teamcback.domain.notification.entity.PushDispatch;
+import devkor.com.teamcback.domain.notification.entity.PushInstallation;
+import devkor.com.teamcback.domain.notification.entity.type.AppVariant;
+import devkor.com.teamcback.domain.notification.entity.type.NotificationType;
+import devkor.com.teamcback.domain.notification.entity.type.PushActionType;
+import devkor.com.teamcback.domain.notification.entity.type.PushDispatchStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMessageStatus;
+import devkor.com.teamcback.domain.notification.entity.type.PushMode;
+import devkor.com.teamcback.domain.notification.entity.type.PushTargetType;
+import devkor.com.teamcback.domain.notification.factory.PushPayloadFactory;
+import devkor.com.teamcback.domain.notification.repository.PushDispatchRepository;
+import devkor.com.teamcback.domain.notification.repository.PushInstallationRepository;
+import devkor.com.teamcback.domain.notification.repository.PushMessageRepository;
+import devkor.com.teamcback.domain.notification.resolver.PushTargetResolver;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import devkor.com.teamcback.global.response.ResultCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminNotificationServiceTest {
+
+    @Mock
+    private PushInstallationRepository pushInstallationRepository;
+
+    @Mock
+    private PushDispatchRepository pushDispatchRepository;
+
+    @Mock
+    private PushMessageRepository pushMessageRepository;
+
+    @Mock
+    private PushTargetResolver pushTargetResolver;
+
+    @Mock
+    private PushPayloadFactory pushPayloadFactory;
+
+    @Mock
+    private PushDispatchService pushDispatchService;
+
+    @Test
+    void searchInstallationsDoesNotExposeExpoPushToken() throws Exception {
+        PushInstallation installation = installation(AppVariant.DEV);
+        when(pushInstallationRepository.findAllByUserIdOrderByModifiedAtDescPushInstallationIdDesc(1L))
+                .thenReturn(List.of(installation));
+
+        List<AdminPushInstallationRes> response = service(false)
+                .searchInstallations(1L, null);
+
+        String json = new ObjectMapper().findAndRegisterModules().writeValueAsString(response);
+        assertThat(json).contains("installationId");
+        assertThat(json).doesNotContain("expoPushToken");
+        assertThat(json).doesNotContain("ExponentPushToken");
+    }
+
+    @Test
+    void previewResolvesTargetAndCreatesPayloadWithoutSavingDispatchOrMessages() {
+        PushInstallation installation = installation(AppVariant.DEV);
+        PushPayload payload = payload();
+
+        when(pushTargetResolver.resolve(PushTargetType.INSTALLATION, "install-1", AppVariant.DEV))
+                .thenReturn(List.of(installation));
+        when(pushPayloadFactory.createForPreDispatchValidation(
+                "title",
+                "body",
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushActionType.TEST,
+                Map.of()
+        )).thenReturn(payload);
+
+        AdminPushDispatchPreviewRes response = service(false).preview(testRequest());
+
+        assertThat(response.recipientCount()).isEqualTo(1);
+        assertThat(response.payload()).isSameAs(payload);
+        verify(pushDispatchRepository, never()).save(any(PushDispatch.class));
+        verify(pushMessageRepository, never()).saveAll(any());
+        verify(pushDispatchService, never()).enqueue(any(PushDispatchCommand.class));
+    }
+
+    @Test
+    void testModeRejectsUserTarget() {
+        AdminPushDispatchReq request = new AdminPushDispatchReq(
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.USER,
+                "1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                Map.of(),
+                null
+        );
+
+        assertThatThrownBy(() -> service(false).preview(request))
+                .isInstanceOf(GlobalException.class)
+                .extracting("resultCode")
+                .isEqualTo(ResultCode.INVALID_INPUT);
+    }
+
+    @Test
+    void productionActualIsRejectedWhenProductionEnabledIsFalse() {
+        assertThatThrownBy(() -> service(false).enqueue(
+                1L,
+                "key-1",
+                productionRequest(true)
+        ))
+                .isInstanceOf(GlobalException.class)
+                .extracting("resultCode")
+                .isEqualTo(ResultCode.FORBIDDEN);
+
+        verify(pushDispatchService, never()).enqueue(any(PushDispatchCommand.class));
+    }
+
+    @Test
+    void productionActualRequiresConfirmTrue() {
+        assertThatThrownBy(() -> service(true).enqueue(
+                1L,
+                "key-1",
+                productionRequest(false)
+        ))
+                .isInstanceOf(GlobalException.class)
+                .extracting("resultCode")
+                .isEqualTo(ResultCode.INVALID_INPUT);
+
+        verify(pushDispatchService, never()).enqueue(any(PushDispatchCommand.class));
+    }
+
+    @Test
+    void enqueueDelegatesToPushDispatchService() {
+        PushDispatch dispatch = dispatch(PushMode.TEST, AppVariant.DEV, PushTargetType.INSTALLATION);
+        PushDispatchEnqueueRes enqueueResponse = new PushDispatchEnqueueRes(dispatch);
+        when(pushDispatchService.enqueue(any(PushDispatchCommand.class)))
+                .thenReturn(enqueueResponse);
+
+        PushDispatchEnqueueRes response = service(false).enqueue(
+                7L,
+                "key-1",
+                testRequest()
+        );
+
+        assertThat(response).isSameAs(enqueueResponse);
+
+        ArgumentCaptor<PushDispatchCommand> captor = ArgumentCaptor.forClass(PushDispatchCommand.class);
+        verify(pushDispatchService).enqueue(captor.capture());
+        PushDispatchCommand command = captor.getValue();
+        assertThat(command.notificationType()).isEqualTo(NotificationType.GENERAL);
+        assertThat(command.mode()).isEqualTo(PushMode.TEST);
+        assertThat(command.appVariant()).isEqualTo(AppVariant.DEV);
+        assertThat(command.targetType()).isEqualTo(PushTargetType.INSTALLATION);
+        assertThat(command.idempotencyKey()).isEqualTo("key-1");
+        assertThat(command.createdBy()).isEqualTo(7L);
+    }
+
+    @Test
+    void getDispatchCountsAllMessageStatuses() {
+        PushDispatch dispatch = dispatch(PushMode.ACTUAL, AppVariant.DEV, PushTargetType.USER);
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        dispatch.updateRecipientCount(5);
+
+        when(pushDispatchRepository.findById(10L)).thenReturn(Optional.of(dispatch));
+        when(pushMessageRepository.countStatusesByDispatchIds(List.of(10L)))
+                .thenReturn(List.of(
+                        new StatusCount(10L, PushMessageStatus.QUEUED, 1L),
+                        new StatusCount(10L, PushMessageStatus.SENDING, 1L),
+                        new StatusCount(10L, PushMessageStatus.DELIVERED, 2L),
+                        new StatusCount(10L, PushMessageStatus.FAILED, 1L)
+                ));
+
+        AdminPushDispatchDetailRes response = service(false).getDispatch(10L);
+
+        assertThat(response.recipientCount()).isEqualTo(5);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.QUEUED, 1L);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.SENDING, 1L);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.TICKET_RECEIVED, 0L);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.RECEIPT_PENDING, 0L);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.DELIVERED, 2L);
+        assertThat(response.messageStatusCounts()).containsEntry(PushMessageStatus.FAILED, 1L);
+    }
+
+    private AdminNotificationService service(boolean productionEnabled) {
+        AdminNotificationService service = new AdminNotificationService(
+                pushInstallationRepository,
+                pushDispatchRepository,
+                pushMessageRepository,
+                pushTargetResolver,
+                pushPayloadFactory,
+                pushDispatchService
+        );
+        ReflectionTestUtils.setField(service, "productionEnabled", productionEnabled);
+        return service;
+    }
+
+    private AdminPushDispatchReq testRequest() {
+        return new AdminPushDispatchReq(
+                PushMode.TEST,
+                AppVariant.DEV,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.TEST,
+                Map.of(),
+                null
+        );
+    }
+
+    private AdminPushDispatchReq productionRequest(boolean confirm) {
+        return new AdminPushDispatchReq(
+                PushMode.ACTUAL,
+                AppVariant.PRODUCTION,
+                PushTargetType.INSTALLATION,
+                "install-1",
+                "title",
+                "body",
+                PushActionType.HOME,
+                Map.of(),
+                confirm
+        );
+    }
+
+    private PushInstallation installation(AppVariant appVariant) {
+        PushInstallation installation = new PushInstallation(
+                1L,
+                "install-1",
+                "ExponentPushToken[token]",
+                appVariant
+        );
+        ReflectionTestUtils.setField(installation, "pushInstallationId", 100L);
+        ReflectionTestUtils.setField(installation, "createdAt", LocalDateTime.parse("2026-08-04T10:00:00"));
+        ReflectionTestUtils.setField(installation, "modifiedAt", LocalDateTime.parse("2026-08-04T11:00:00"));
+        return installation;
+    }
+
+    private PushPayload payload() {
+        return new PushPayload(
+                "title",
+                "body",
+                new PushPayload.PushPayloadData(
+                        1,
+                        "00000000-0000-4000-8000-000000000000",
+                        new PushPayload.PushPayloadAction(PushActionType.TEST.name(), Map.of())
+                )
+        );
+    }
+
+    private PushDispatch dispatch(
+            PushMode mode,
+            AppVariant appVariant,
+            PushTargetType targetType
+    ) {
+        PushDispatch dispatch = new PushDispatch(
+                NotificationType.GENERAL,
+                mode,
+                appVariant,
+                targetType,
+                targetType == PushTargetType.USER ? "1" : "install-1",
+                "title",
+                "body",
+                mode == PushMode.TEST ? PushActionType.TEST : PushActionType.HOME,
+                "{}",
+                "key-1",
+                1L,
+                LocalDateTime.parse("2026-08-04T12:00:00")
+        );
+        ReflectionTestUtils.setField(dispatch, "pushDispatchId", 10L);
+        return dispatch;
+    }
+
+    private static class StatusCount implements PushMessageRepository.PushDispatchMessageStatusCount {
+
+        private final Long dispatchId;
+        private final PushMessageStatus status;
+        private final long count;
+
+        private StatusCount(
+                Long dispatchId,
+                PushMessageStatus status,
+                long count
+        ) {
+            this.dispatchId = dispatchId;
+            this.status = status;
+            this.count = count;
+        }
+
+        @Override
+        public Long getDispatchId() {
+            return dispatchId;
+        }
+
+        @Override
+        public PushMessageStatus getStatus() {
+            return status;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 관리자 푸시 대상 installation 검색 API를 추가했습니다.
- 실제 발송 전 대상 수와 payload를 확인할 수 있는 미리보기 API를 추가했습니다.
- 관리자가 수동으로 푸시 발송 작업을 생성할 수 있는 API를 추가했습니다.
- 푸시 발송 이력 및 상태별 처리 결과 조회 API를 추가했습니다.
- 각 관리자 API에 Swagger `@Operation` 설명을 추가했습니다.

## 주요 설계
- 관리자 API에서 Expo Push API를 직접 호출하지 않고, 기존 `PushDispatchService`와 worker 발송 파이프라인을 재사용합니다.
- 미리보기 요청은 대상과 payload만 검증하며 `PushDispatch`, `PushMessage`를 저장하지 않습니다.
- `Idempotency-Key`를 기존 발송 멱등 처리에 전달하여 중복 발송을 방지합니다.
- TEST 발송은 단일 installation만 허용합니다.
- production 실제 발송은 `push.admin.production-enabled=true` 및 `confirm=true`인 경우에만 허용합니다.
- installation 검색 및 발송 결과 응답에서 ExpoPushToken 원문을 반환하지 않습니다.

## 관련 이슈
- 
