### PR TITLE
hotfix: allow Kakao admin login without email claim

### DIFF
--- a/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
+++ b/src/main/java/devkor/com/teamcback/domain/user/validator/KakaoValidator.java
@@ -56,12 +56,26 @@ public class KakaoValidator{
 
             OIDCDecodePayload payload = oidcUtil.getOIDCTokenBody(token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
 
-            return payload.getEmail();
+            return resolveEmail(payload);
         } catch(GlobalException e) {
             redisUtil.deleteCache("kakao::data");
             throw new GlobalException(e.getResultCode());
         } catch (Exception e) {
             throw new GlobalException(INVALID_TOKEN);
         }
+    }
+
+    String resolveEmail(OIDCDecodePayload payload) {
+        String email = payload.getEmail();
+        if (email != null && !email.isBlank()) {
+            return email;
+        }
+
+        String subject = payload.getSub();
+        if (subject == null || subject.isBlank()) {
+            throw new GlobalException(INVALID_TOKEN);
+        }
+
+        return "kakao_" + subject + "@noemail.kodaero.invalid";
     }
 }

--- a/src/test/java/devkor/com/teamcback/domain/user/validator/KakaoValidatorTest.java
+++ b/src/test/java/devkor/com/teamcback/domain/user/validator/KakaoValidatorTest.java
@@ -1,0 +1,65 @@
+package devkor.com.teamcback.domain.user.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import devkor.com.teamcback.domain.user.validator.client.KakaoClient;
+import devkor.com.teamcback.global.exception.exception.GlobalException;
+import devkor.com.teamcback.global.jwt.OIDC.OIDCUtil;
+import devkor.com.teamcback.global.jwt.OIDC.dto.OIDCDecodePayload;
+import devkor.com.teamcback.global.redis.RedisUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class KakaoValidatorTest {
+    KakaoValidator kakaoValidator;
+
+    @BeforeEach
+    void setUp() {
+        kakaoValidator = new KakaoValidator(
+            Mockito.mock(OIDCUtil.class),
+            Mockito.mock(KakaoClient.class),
+            Mockito.mock(RedisUtil.class)
+        );
+    }
+
+    @Test
+    void keepsEmailFromVerifiedToken() {
+        OIDCDecodePayload payload = new OIDCDecodePayload(
+            "https://kauth.kakao.com",
+            "client-id",
+            "123456789",
+            "member@example.com"
+        );
+
+        assertEquals("member@example.com", kakaoValidator.resolveEmail(payload));
+    }
+
+    @Test
+    void createsStableInternalEmailWhenKakaoEmailIsMissing() {
+        OIDCDecodePayload payload = new OIDCDecodePayload(
+            "https://kauth.kakao.com",
+            "client-id",
+            "123456789",
+            null
+        );
+
+        assertEquals(
+            "kakao_123456789@noemail.kodaero.invalid",
+            kakaoValidator.resolveEmail(payload)
+        );
+    }
+
+    @Test
+    void rejectsTokenWithoutEmailAndSubject() {
+        OIDCDecodePayload payload = new OIDCDecodePayload(
+            "https://kauth.kakao.com",
+            "client-id",
+            null,
+            null
+        );
+
+        assertThrows(GlobalException.class, () -> kakaoValidator.resolveEmail(payload));
+    }
+}


### PR DESCRIPTION
## Scope
- when a Kakao ID token has no email claim, derive a stable internal identifier from the verified OIDC subject
- preserve the existing email path when Kakao supplies email
- no push, store, survey, BLE, or other develop changes

## Verification
- full Gradle test suite passes
- production diff is limited to KakaoValidator and its unit test

## Deployment
After merge, run the production workflow twice so the same image reaches both latest and HTTPS stable slots.